### PR TITLE
COD-4 Translate an object to a landmark on another object by specifying the two objects and two named landmarks or points on those objects

### DIFF
--- a/blender/blenderExecute.py
+++ b/blender/blenderExecute.py
@@ -402,6 +402,11 @@ def blenderAssignObjectToCollection(existingObjectName, collectionName = "Scene 
     
     collection.objects.link(blenderObject)
 
+def blenderCreateArmatures(name):
+    armature = bpy.data.armatures.new(name)
+    object = bpy.data.objects.new(name, armature)
+    
+
 
 def blenderApplyDependencyGraph(existingObjectName, removeModifiers = True):
     
@@ -439,6 +444,22 @@ def blenderAddConstraint(shapeName, constraintType, keywordArguments):
 
 def blenderAddJoint(shape1Name, shape2Name, shape1Landmark, shape2Landmark):
     pass
+
+def blenderTransformLandmarkOntoAnother(shape1Name, shape2Name, shape1Landmark, shape2Landmark):
+
+    blenderObject1 = bpy.data.objects.get(shape1Name)
+    [blenderObject1Landmark] = filter(lambda child: child.name == shape1Landmark, blenderObject1.children)
+    blenderObject2 = bpy.data.objects.get(shape2Name)
+    [blenderObject2Landmark] = filter(lambda child: child.name == shape2Landmark, blenderObject2.children)
+
+    # transform landmark1 onto landmark2
+    t1 = blenderObject1Landmark.matrix_world.inverted() @ blenderObject2Landmark.matrix_world
+    # transform object onto landmark1
+    t2 = blenderObject1.matrix_world.inverted() @ blenderObject1Landmark.matrix_world
+
+    # transform the object onto landmark1, the result onto landmark2, then restore the transform of the object onto the landmark to maintain their position 
+    blenderObject1.matrix_world = blenderObject1.matrix_world.copy() @ t2 @ t1 @ t2.inverted()
+
 
 def blenderMakeParent(name, parentName):
     blenderObject = bpy.data.objects.get(name)

--- a/blender/tests/gokart.py
+++ b/blender/tests/gokart.py
@@ -6,9 +6,9 @@ if scriptDir not in sys.path:
 
 
 import bpy
-from textToBlender import shape, scene, BlenderLength
+from textToBlender import shape, scene, BlenderLength, joint
 
-scene().setDefaultUnit(BlenderLength.INCHES)
+# scene().setDefaultUnit(BlenderLength.INCHES)
 
 sprocket = {
   "source": str(Path(__file__).parent.absolute()) + "/testFiles/6280K267_Roller Chain Sprocket.stl"
@@ -98,7 +98,10 @@ features = {
 
 # shape("sprocket").fromFile(sprocket["source"]).scale(",3in,")
 
-shape("Half Axle rod").primitive("cylinder", features["Half Axle rod"]["dimensions"]).landmark("top", "center,center,max")
+shape("Half Axle rod").primitive("cylinder", features["Half Axle rod"]["dimensions"]).landmark("top", "center,center,max").rotate(["10d","20d",0])
+shape("Half Axle rod2").primitive("cylinder", features["Half Axle rod"]["dimensions"]).landmark("bottom", "center,center,min").translate([0,0,30])
+
+joint("Half Axle rod2", "Half Axle rod", "bottom", "top").transformLandmarkOntoAnother()
 # shape("Axle teeth").primitive("cube", features["Axle teeth"]["dimensions"])
 # shape("bearing rod").primitive("cube", features["bearing rod"]["dimensions"])
 # shape("breakdisc rod").primitive("cube", features["breakdisc rod"]["dimensions"])

--- a/blender/textToBlender.py
+++ b/blender/textToBlender.py
@@ -333,7 +333,7 @@ class shape:
         blenderEvents.addToBlenderOperationsQueue(
             "Creating landmark {} on {}.".format(landmarkName, self.name),
             lambda: blenderAddLandmark(self.name, landmarkName, localPosition),
-            lambda update: type(update.id) == bpy.types.Object and update.id.name == self.name
+            lambda update: type(update.id) == bpy.types.Object and update.id.name == landmarkName
         )
 
         return self
@@ -397,10 +397,10 @@ class joint:
     shape2Name:str, \
     shape1Landmark:str, \
     shape2Landmark:str, \
-    jointType:str, \
-    initialRotation:str, \
-    limitRotation:str, \
-    limitTranslation:str \
+    jointType:str = None, \
+    initialRotation:str = None, \
+    limitRotation:str = None, \
+    limitTranslation:str = None \
     ):
         self.shape1Name = shape1Name
         self.shape2Name = shape2Name
@@ -410,6 +410,18 @@ class joint:
         self.initialRotation = initialRotation
         self.limitRotation = limitRotation
         self.limitTranslation = limitTranslation
+
+        
+    def transformLandmarkOntoAnother(self):
+        
+        blenderEvents.addToBlenderOperationsQueue(
+            "Transforming {} landmark {} onto {} landmark {}".format(self.shape1Name, self.shape2Name, self.shape1Landmark, self.shape2Landmark),
+            lambda: blenderTransformLandmarkOntoAnother(self.shape1Name, self.shape2Name, self.shape1Landmark, self.shape2Landmark),
+            # lambda update: type(update.id) == bpy.types.Object and update.id.name == self.name,
+            None
+        )
+
+        return self
 
 class material: 
     # Text to 3D Modeling Automation Capabilities.

--- a/blender/utilities.py
+++ b/blender/utilities.py
@@ -44,10 +44,12 @@ class AngleUnit(Units):
             "radians": AngleUnit.RADIANS,
             "rad": AngleUnit.RADIANS,
             "rads": AngleUnit.RADIANS,
+            "r": AngleUnit.RADIANS,
             "degrees": AngleUnit.DEGREES,
             "degree": AngleUnit.DEGREES,
             "degs": AngleUnit.DEGREES,
-            "deg": AngleUnit.DEGREES
+            "deg": AngleUnit.DEGREES,
+            "d": AngleUnit.DEGREES
         }
         return aliases[fromString.lower()]
 


### PR DESCRIPTION
- Fixed landmark assertion.
- Added d and r as aliases for degrees and radians.
- Added the Joint ability to transform one landmark onto another.