### PR TITLE
bug/translation_offsets

### DIFF
--- a/CodeToCAD/CodeToCADInterface.py
+++ b/CodeToCAD/CodeToCADInterface.py
@@ -1727,3 +1727,14 @@ class Analytics(metaclass=ABCMeta):
         print("getDimensions is called in an abstract method. Please override this method.")
         raise NotImplementedError()
         
+
+    @abstractmethod
+    def log(self, message:str
+    ):
+        '''
+        Write a message
+        '''
+        
+        print("log is called in an abstract method. Please override this method.")
+        raise NotImplementedError()
+        

--- a/CodeToCAD/CodeToCADInterface.py
+++ b/CodeToCAD/CodeToCADInterface.py
@@ -99,7 +99,7 @@ class Entity(metaclass=ABCMeta):
         
 
     @abstractmethod
-    def apply(self
+    def apply(self, rotation:bool=True, scale:bool=True, location:bool=False, modifiers:bool=True
     ):
         '''
         Apply any modifications. This is application specific, but a general function is that it finalizes any changes made to an entity.

--- a/CodeToCAD/CodeToCADProvider.py
+++ b/CodeToCAD/CodeToCADProvider.py
@@ -1009,4 +1009,10 @@ class Analytics(CodeToCADInterface.Analytics):
         
         raise NotImplementedError()
         
+
+    def log(self, message:str
+    ):
+        
+        raise NotImplementedError()
+        
     

--- a/CodeToCAD/CodeToCADProvider.py
+++ b/CodeToCAD/CodeToCADProvider.py
@@ -58,7 +58,7 @@ class Entity(CodeToCADInterface.Entity):
         return self
         
 
-    def apply(self
+    def apply(self, rotation:bool=True, scale:bool=True, location:bool=False, modifiers:bool=True
     ):
         
         return self

--- a/CodeToCAD/TestCodeToCADProvider.py
+++ b/CodeToCAD/TestCodeToCADProvider.py
@@ -76,7 +76,7 @@ class TestEntity(TestProviderCase):
     def test_apply(self):
         instance = Part("name","description")
 
-        value = instance.apply("")
+        value = instance.apply("rotation","scale","location","modifiers")
 
         
         assert value, "Modify method failed."

--- a/CodeToCAD/TestCodeToCADProvider.py
+++ b/CodeToCAD/TestCodeToCADProvider.py
@@ -1337,3 +1337,12 @@ class TestAnalytics(TestProviderCase):
         
         assert value, "Get method failed."
         
+    @unittest.skip
+    def test_log(self):
+        instance = Analytics("")
+
+        value = instance.log("message")
+
+        
+        assert value, "Get method failed."
+        

--- a/CodeToCAD/capabilities.json
+++ b/CodeToCAD/capabilities.json
@@ -1904,6 +1904,15 @@
                         "type": "string,Entity"
                     }
                 }
+            },
+            "log": {
+                "action": "get",
+                "information": "Write a message",
+                "parameters": {
+                    "message": {
+                        "type": "string"
+                    }
+                }
             }
         }
     }

--- a/CodeToCAD/capabilities.json
+++ b/CodeToCAD/capabilities.json
@@ -72,7 +72,24 @@
             "apply": {
                 "action": "modify",
                 "information": "Apply any modifications. This is application specific, but a general function is that it finalizes any changes made to an entity.",
-                "parameters": {}
+                "parameters": {
+                    "rotation": {
+                        "type": "boolean",
+                        "defaultValue": true
+                    },
+                    "scale": {
+                        "type": "boolean",
+                        "defaultValue": true
+                    },
+                    "location": {
+                        "type": "boolean",
+                        "defaultValue": false
+                    },
+                    "modifiers": {
+                        "type": "boolean",
+                        "defaultValue": true
+                    }
+                }
             },
             "getNativeInstance": {
                 "action": "get",

--- a/CodeToCAD/utilities.py
+++ b/CodeToCAD/utilities.py
@@ -14,7 +14,7 @@ min = "min"
 max = "max"
 center = "center"
 
-reservedWords = ["min", "max", "center"]
+reservedWords = [min, max, center]
 
 
 def isReservedWordInString(stringToCheck: str) -> bool:
@@ -172,24 +172,29 @@ class Angle():
 
     def __lt__(self, other):
         other = self.arithmeticPrecheckAndUnitConversion(other)
+        assert self.unit == other.unit, "Units are not matching for comparison."
         return self.value < other.value
 
     def __le__(self, other):
         other = self.arithmeticPrecheckAndUnitConversion(other)
+        assert self.unit == other.unit, "Units are not matching for comparison."
         return self.value <= other.value
 
     def __gt__(self, other):
         other = self.arithmeticPrecheckAndUnitConversion(other)
+        assert self.unit == other.unit, "Units are not matching for comparison."
         return self.value > other.value
 
     def __ge__(self, other):
         other = self.arithmeticPrecheckAndUnitConversion(other)
+        assert self.unit == other.unit, "Units are not matching for comparison."
         return self.value >= other.value
 
     def __eq__(self, other):
         if other == None:
             return False
         other = self.arithmeticPrecheckAndUnitConversion(other)
+        assert self.unit == other.unit, "Units are not matching for comparison."
         return self.value == other.value
 
     def __ne__(self, other):
@@ -497,27 +502,27 @@ class Dimension():
 
     def __add__(self, other):
         other = self.arithmeticPrecheckAndUnitConversion(other)
-        return Dimension(self.value + other.value, self.unit)
+        return Dimension(self.value + other.value, self.unit or other.unit)
 
     def __sub__(self, other):
         other = self.arithmeticPrecheckAndUnitConversion(other)
-        return Dimension(self.value - other.value, self.unit)
+        return Dimension(self.value - other.value, self.unit or other.unit)
 
     def __mul__(self, other):
         other = self.arithmeticPrecheckAndUnitConversion(other)
-        return Dimension(self.value * other.value, self.unit)
+        return Dimension(self.value * other.value, self.unit or other.unit)
 
     def __truediv__(self, other):
         other = self.arithmeticPrecheckAndUnitConversion(other)
-        return Dimension(self.value / other.value, self.unit)
+        return Dimension(self.value / other.value, self.unit or other.unit)
 
     def __floordiv__(self, other):
         other = self.arithmeticPrecheckAndUnitConversion(other)
-        return Dimension(self.value // other.value, self.unit)
+        return Dimension(self.value // other.value, self.unit or other.unit)
 
     def __mod__(self, other):
         other = self.arithmeticPrecheckAndUnitConversion(other)
-        return Dimension(self.value % other.value, self.unit)
+        return Dimension(self.value % other.value, self.unit or other.unit)
 
     # def __divmod__(self, other):
     #     other = self.arithmeticPrecheckAndUnitConversion(other)
@@ -525,31 +530,36 @@ class Dimension():
 
     def __pow__(self, other, mod=None):
         other = self.arithmeticPrecheckAndUnitConversion(other)
-        return Dimension(pow(self.value, other.value, mod), self.unit)
+        return Dimension(pow(self.value, other.value, mod), self.unit or other.unit)
 
     def __abs__(self):
         return Dimension(abs(self.value), self.unit)
 
     def __lt__(self, other):
         other = self.arithmeticPrecheckAndUnitConversion(other)
+        assert self.unit == other.unit, "Units are not matching for comparison."
         return self.value < other.value
 
     def __le__(self, other):
         other = self.arithmeticPrecheckAndUnitConversion(other)
+        assert self.unit == other.unit, "Units are not matching for comparison."
         return self.value <= other.value
 
     def __gt__(self, other):
         other = self.arithmeticPrecheckAndUnitConversion(other)
+        assert self.unit == other.unit, "Units are not matching for comparison."
         return self.value > other.value
 
     def __ge__(self, other):
         other = self.arithmeticPrecheckAndUnitConversion(other)
+        assert self.unit == other.unit, "Units are not matching for comparison."
         return self.value >= other.value
 
     def __eq__(self, other):
         if other == None:
             return False
         other = self.arithmeticPrecheckAndUnitConversion(other)
+        assert self.unit == other.unit, "Units are not matching for comparison."
         return self.value == other.value
 
     def __ne__(self, other):

--- a/examples/ballJoint.py
+++ b/examples/ballJoint.py
@@ -18,7 +18,7 @@ socket_center = socket.createLandmark("center", center, center, center)
 Joint(ball_bottom, socket_cutoff).translateLandmarkOntoAnother()
 
 socket.subtract(ball, deleteAfterSubtract=False,
-                isTransferLandmarks=False).apply()
+                isTransferLandmarks=False)
 
 Joint(socket_center, ball) \
     .limitRotationX(-30, 30) \

--- a/examples/bracelet.py
+++ b/examples/bracelet.py
@@ -36,23 +36,23 @@ buttonInnerYTranslation = (
 
 Part("bracelet") \
     .createTorus(f"{bracelet['innerDiameter']/2}cm", f"{bracelet['outerDiameter']/2}cm") \
-    .scaleZ(f"{bracelet['thickness']}cm").apply()  # Scale x,y by a scale factor of 1, so the number is unitless
+    .scaleZ(f"{bracelet['thickness']}cm")  # Scale x,y by a scale factor of 1, so the number is unitless
 
 Part("button") \
     .createCylinder(f"{button['diameter']/2}cm", f"{button['depth']}cm") \
     .rotateXYZ(90, 0, 0) \
-    .translateXYZ(0, f"{buttonTranslation}cm", 0).apply()
+    .translateXYZ(0, f"{buttonTranslation}cm", 0)
 
 Part("buttonInner") \
     .createCylinder(f"{buttonInner['diameter']/2}cm", f"{buttonInner['depth']}cm") \
     .rotateXYZ(90, 0, 0) \
-    .translateXYZ(0, f"{buttonInnerYTranslation}cm", 0).apply()
+    .translateXYZ(0, f"{buttonInnerYTranslation}cm", 0)
 
 Part("belt") \
-    .createCylinder(f"{belt['outerDiameter']/2}cm", f"{belt['thickness']}cm").apply()
+    .createCylinder(f"{belt['outerDiameter']/2}cm", f"{belt['thickness']}cm")
 
 Part("beltInner") \
-    .createCylinder(f"{belt['innerDiameter']/2}cm", f"{belt['thickness']}cm").apply()
+    .createCylinder(f"{belt['innerDiameter']/2}cm", f"{belt['thickness']}cm")
 
 
 Part("button")\

--- a/examples/calibrationCube.py
+++ b/examples/calibrationCube.py
@@ -18,7 +18,7 @@ def createCube(name, size):
         "size", "min+1mm", "min+2mm", max)
 
     z = Sketch("Z").createText("Z^", "10mm").extrude("1.5mm").rotateXYZ(
-        90, 0, 0).apply()
+        90, 0, 0)
     z_center = z.createLandmark("center", center, center, center)
     Joint(calibrationCube_z, z_center).limitLocationXYZ(0, 0, 0)
     calibrationCube.subtract(z)

--- a/examples/dShaftKnob.py
+++ b/examples/dShaftKnob.py
@@ -1,0 +1,56 @@
+from CodeToCAD import Analytics, Part, Sketch, Scene, Dimension, min, center, max as part_max, Joint, CodeToCADInterface
+
+Scene.default().setDefaultUnit("mm")
+
+tolerance = "0.15mm"
+
+
+def createDShaft(shaftLength, radius, dProfileRadius):
+    shaftLength = Dimension.fromString(shaftLength) + tolerance
+    radius = Dimension.fromString(radius) + tolerance
+    dProfileRadius = Dimension.fromString(dProfileRadius) + tolerance
+
+    dProfileWidth = (radius - dProfileRadius) * 2
+
+    shaft = Part("shaft").createCylinder(radius, shaftLength)
+
+    dProfile = Part("dProfile").createCube(
+        dProfileWidth, radius * 2, shaftLength)
+
+    shaftLeftSide = shaft.createLandmark("left", min, center, center)
+    dProfileLeftSide = dProfile.createLandmark("left", min, center, center)
+
+    Joint(shaftLeftSide, dProfileLeftSide).limitLocationXYZ(0, 0, 0)
+
+    shaft.subtract(dProfile)
+
+    return shaft
+
+
+def createDShaftSleeve(dShaft: CodeToCADInterface.Part, sleeveThickness):
+    dShaftDiameter = dShaft.getDimensions().y
+
+    sleeve = Part("sleeve").createCylinder(
+        dShaftDiameter/2 + sleeveThickness, dShaft.getDimensions().z)
+
+    sleeve.subtract(dShaft, isTransferLandmarks=True)
+
+    return sleeve
+
+
+def createKnob(radius):
+    knob = Sketch("knob").createPolygon(7, radius, radius).extrude(radius*0.2)
+
+    return knob
+
+
+dShaft = createDShaft("13.65mm",  "5.9/2mm", "5.3/2mm")
+
+sleeve = createDShaftSleeve(dShaft, "1.5mm")
+
+knob = createKnob(sleeve.getDimensions().x)
+
+Joint(sleeve.createLandmark("top", center, center, part_max), knob.createLandmark(
+    "bottom", center, center, min)).limitLocationXYZ(0, 0, 0)
+
+sleeve.union(knob).export("./appliance_knob.stl", scale=1000)

--- a/examples/patterning.py
+++ b/examples/patterning.py
@@ -1,7 +1,7 @@
 from CodeToCAD import *
 
-Part("Linear Cube").createCube(
-    "5cm", "5cm", "5cm").linearPattern(10, "x", "7cm")
+linearCube = Part("Linear Cube").createCube(
+    "5cm", "5cm", "5cm").linearPattern(10, "7cm", "x")
 
 Part("Circular spheres").createSphere(1).translateXYZ(0, 5, 0).circularPattern(
-    4, "90d", "z", "Linear Cube").circularPattern(6, f"{360/6}d", "x", "Linear Cube")
+    4, "90d", linearCube, "z").circularPattern(6, f"{360/6}d", linearCube, "x")

--- a/examples/simpleHumanoid.py
+++ b/examples/simpleHumanoid.py
@@ -12,7 +12,7 @@ head_bottom = head.createLandmark("bottom", center, center, min)
 eye = Part("eye").createCylinder(0.1, 0.1)
 eye_bottom = eye.createLandmark("bottom", center, center, min)
 
-eye.rotateXYZ(0, 90, 0).apply()
+eye.rotateXYZ(0, 90, 0)
 
 # Mark: Attach head to Body
 Joint(body_top, head_bottom).limitLocationXYZ(

--- a/providers/blender/BlenderActions.py
+++ b/providers/blender/BlenderActions.py
@@ -171,8 +171,8 @@ def applyBooleanModifier(
             {
                 "operation": blenderBooleanType.name,
                 "object": blenderBooleanObject,
-                # "use_self": True,
-                # "use_hole_tolerant": True,
+                "use_self": True,
+                "use_hole_tolerant": True,
                 # "solver": "EXACT",
                 # "double_threshold": 1e-6
             },

--- a/providers/blender/BlenderActions.py
+++ b/providers/blender/BlenderActions.py
@@ -122,7 +122,8 @@ def applySolidifyModifier(
         BlenderDefinitions.BlenderModifiers.SOLIDIFY,
         dict(
             {
-                "thickness": BlenderDefinitions.BlenderLength.convertDimensionToBlenderUnit(thickness).value
+                "thickness": BlenderDefinitions.BlenderLength.convertDimensionToBlenderUnit(thickness).value,
+                "offset": 0
             },
             **keywordArguments
         )

--- a/providers/blender/BlenderProvider.py
+++ b/providers/blender/BlenderProvider.py
@@ -101,20 +101,26 @@ class Entity(CodeToCADInterface.Entity):
 
         return self
 
-    def apply(self
-              ):
+    def apply(self, rotation=True, scale=True, location=False, modifiers=True):
 
         BlenderActions.updateViewLayer()
 
-        BlenderActions.applyDependencyGraph(self.name)
+        if modifiers:
+            BlenderActions.applyDependencyGraph(self.name)
 
-        BlenderActions.removeMesh(self.name)
+            BlenderActions.removeMesh(self.name)
 
-        BlenderActions.updateObjectDataName(self.name, self.name)
+            BlenderActions.updateObjectDataName(self.name, self.name)
 
-        BlenderActions.clearModifiers(self.name)
+            BlenderActions.clearModifiers(self.name)
 
-        BlenderActions.applyObjectRotationAndScale(self.name)
+        if rotation and scale and location:
+            BlenderActions.applyObjectTransformations(self.name)
+        elif rotation and scale:
+            BlenderActions.applyObjectRotationAndScale(self.name)
+        else:
+            raise NotImplementedError(
+                "Applying rotation, scale or location separately is not yet supported.")
 
         return self
 
@@ -538,7 +544,7 @@ class Part(Entity, CodeToCADInterface.Part):
 
     def createCone(self, radius: DimensionOrItsFloatOrStringValue, height: DimensionOrItsFloatOrStringValue, draftRadius: DimensionOrItsFloatOrStringValue = 0, keywordArguments: Optional[dict] = None
                    ):
-        return self._createPrimitive("cone", "{},{},{}".format(radius, height, draftRadius), keywordArguments)
+        return self._createPrimitive("cone", "{},{},{}".format(radius, draftRadius, height), keywordArguments)
 
     def createCylinder(self, radius: DimensionOrItsFloatOrStringValue, height: DimensionOrItsFloatOrStringValue, keywordArguments: Optional[dict] = None
                        ):

--- a/providers/blender/BlenderProvider.py
+++ b/providers/blender/BlenderProvider.py
@@ -268,7 +268,7 @@ class Entity(CodeToCADInterface.Entity):
             amount, boundingBox.x)
 
         BlenderActions.translateObject(
-            self.name, [dimension, Dimension(0), Dimension(0)], BlenderDefinitions.BlenderTranslationTypes.ABSOLUTE)
+            self.name, [dimension, None, None], BlenderDefinitions.BlenderTranslationTypes.ABSOLUTE)
 
         return self
 
@@ -283,7 +283,7 @@ class Entity(CodeToCADInterface.Entity):
             amount, boundingBox.y)
 
         BlenderActions.translateObject(
-            self.name, [Dimension(0), dimension, Dimension(0)], BlenderDefinitions.BlenderTranslationTypes.ABSOLUTE)
+            self.name, [None, dimension, None], BlenderDefinitions.BlenderTranslationTypes.ABSOLUTE)
 
         return self
 
@@ -298,7 +298,7 @@ class Entity(CodeToCADInterface.Entity):
             amount, boundingBox.z)
 
         BlenderActions.translateObject(
-            self.name, [Dimension(0), Dimension(0), dimension], BlenderDefinitions.BlenderTranslationTypes.ABSOLUTE)
+            self.name, [None, None, dimension], BlenderDefinitions.BlenderTranslationTypes.ABSOLUTE)
 
         return self
 

--- a/providers/blender/CodeToCADBlenderAddon.py
+++ b/providers/blender/CodeToCADBlenderAddon.py
@@ -115,9 +115,9 @@ def reloadCodeToCADModules():
     import BlenderDefinitions
     import BlenderProvider
     import CodeToCADInterface
-    import utilities
+    import CodeToCAD.utilities
 
-    reload(utilities)
+    reload(CodeToCAD.utilities)
     reload(CodeToCADInterface)
     reload(BlenderProvider)
     reload(BlenderDefinitions)
@@ -126,6 +126,8 @@ def reloadCodeToCADModules():
 
     from BlenderProvider import injectBlenderProvider
     injectBlenderProvider(globals())
+
+    addCodeToCADToBlenderConsole()
 
 
 class ImportedFileWatcher():
@@ -480,6 +482,10 @@ class CodeToCADPanel(bpy.types.Panel):
                              icon='PREFERENCES', text="Open Preferences")
 
 
+def addCodeToCADToBlenderConsole():
+    console_python.replace_help = addCodeToCADConvenienceWordsToConsole
+
+
 def register():
     print("Registering ", __name__)
     bpy.utils.register_class(CodeToCADAddonPreferences)
@@ -496,7 +502,7 @@ def register():
 
     bpy.app.timers.register(addCodeToCADToPath)
 
-    console_python.replace_help = addCodeToCADConvenienceWordsToConsole
+    addCodeToCADToBlenderConsole()
 
 
 def unregister():

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1277,3 +1277,11 @@ class TestAnalytics(TestProviderCase):
         value = instance.getDimensions("entityName")
 
         assert value, "Get method failed."
+
+    @unittest.skip
+    def test_log(self):
+        instance = Analytics("")
+
+        value = instance.log("message")
+
+        assert value, "Get method failed."

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -106,7 +106,7 @@ class TestEntity(TestProviderCase):
 
         value = instance.getLocationWorld()
 
-        assert value.x == 0 and value.y == 0 and value.z == 0, "Get method failed."
+        assert value.x == "0m" and value.y == "0m" and value.z == "0m", "Get method failed."
 
         # TODO: get location world after translating
 
@@ -115,7 +115,7 @@ class TestEntity(TestProviderCase):
 
         value = instance.getLocationWorld()
 
-        assert value.x == 0 and value.y == 0 and value.z == 0, "Get method failed."
+        assert value.x == "0m" and value.y == "0m" and value.z == "0m", "Get method failed."
 
         # TODO: get location world after translating
 
@@ -201,7 +201,7 @@ class TestEntity(TestProviderCase):
         assert value, "Modify method failed."
 
         assert instance.getLocationWorld() == Point(
-            Dimension(5), Dimension(7), Dimension(9)), "Translation is not correct"
+            Dimension(5, "m"), Dimension(7, "m"), Dimension(9, "m")), "Translation is not correct"
 
     def test_translateX(self):
         instance = Part("name", "description").createCube(1, 1, 1)
@@ -211,7 +211,7 @@ class TestEntity(TestProviderCase):
         assert value, "Modify method failed."
 
         assert instance.getLocationWorld() == Point(
-            Dimension(5), Dimension(0), Dimension(0)), "Translation is not correct"
+            Dimension(5, "m"), Dimension(0, "m"), Dimension(0, "m")), "Translation is not correct"
 
     def test_translateY(self):
         instance = Part("name", "description").createCube(1, 1, 1)
@@ -221,7 +221,7 @@ class TestEntity(TestProviderCase):
         assert value, "Modify method failed."
 
         assert instance.getLocationWorld() == Point(
-            Dimension(0), Dimension(5), Dimension(0)), "Translation is not correct"
+            Dimension(0, "m"), Dimension(5, "m"), Dimension(0, "m")), "Translation is not correct"
 
     def test_translateZ(self):
         instance = Part("name", "description").createCube(1, 1, 1)
@@ -231,7 +231,7 @@ class TestEntity(TestProviderCase):
         assert value, "Modify method failed."
 
         assert instance.getLocationWorld() == Point(
-            Dimension(0), Dimension(0), Dimension(5)), "Translation is not correct"
+            Dimension(0, "m"), Dimension(0, "m"), Dimension(5, "m")), "Translation is not correct"
 
     def test_scaleXYZ(self):
         instance = Part("name", "description").createCube(1, 1, 1)
@@ -383,9 +383,9 @@ class TestEntity(TestProviderCase):
         value = instance.getDimensions()
 
         assert value, "Get method failed."
-        assert value.height == 1
-        assert value.width == 1
-        assert value.length == 1
+        assert value.height == "1m"
+        assert value.width == "1m"
+        assert value.length == "1m"
 
     def test_getLandmark(self):
         instance = Part("name", "description").createCube(1, 1, 1)
@@ -396,9 +396,9 @@ class TestEntity(TestProviderCase):
         valueLocation = value.getLocationWorld()
 
         assert value, "Get method failed."
-        assert valueLocation.x == 0.5
-        assert valueLocation.y == 0.5
-        assert valueLocation.z == 0.5
+        assert valueLocation.x == "0.5m"
+        assert valueLocation.y == "0.5m"
+        assert valueLocation.z == "0.5m"
 
 
 class TestPart(TestProviderCase):


### PR DESCRIPTION
- Added a D-Shaft knob example.
- added log message to Analytics.
- Dimension equality now checks unit equality.
- BlenderProvider now applies modifiers by default. Updated MockBlender to support applying modifiers and updating matrix_world affine transformations.
- apply() now accepts parameters to specify which transformations to apply. Fixed cone primitive for Blender not working correctly.
- Fixed translate for a single axis setting zero  to the other axes. ApplySolidifyModifier now has an offset of 0.