### PR TITLE
Blender addon adds to path without a timer

### DIFF
--- a/providers/blender/CodeToCADBlenderAddon.py
+++ b/providers/blender/CodeToCADBlenderAddon.py
@@ -500,7 +500,7 @@ def register():
     bpy.utils.register_class(LogMessage)
     bpy.utils.register_class(ReloadCodeToCADModules)
 
-    bpy.app.timers.register(addCodeToCADToPath)
+    addCodeToCADToPath()
 
     addCodeToCADToBlenderConsole()
 


### PR DESCRIPTION
this fixes a bug with running scripts headless in Blender.