### PR TITLE
168 thicken modifier doesnt work for 2d curves

### DIFF
--- a/CodeToCAD/CodeToCADInterface.py
+++ b/CodeToCAD/CodeToCADInterface.py
@@ -530,6 +530,16 @@ class Part(Entity,metaclass=ABCMeta):
         
 
     @abstractmethod
+    def thicken(self, radius:DimensionOrItsFloatOrStringValue):
+        '''
+        Uniformly add a wall around a Part.
+        '''
+        
+        print("thicken is called in an abstract method. Please override this method.")
+        return self
+        
+
+    @abstractmethod
     def hole(self, holeLandmark:LandmarkOrItsName, radius:DimensionOrItsFloatOrStringValue, depth:DimensionOrItsFloatOrStringValue, normalAxis:AxisOrItsIndexOrItsName="z", flipAxis:bool=False, initialRotationX:AngleOrItsFloatOrStringValue=0.0, initialRotationY:AngleOrItsFloatOrStringValue=0.0, initialRotationZ:AngleOrItsFloatOrStringValue=0.0, mirrorAboutEntityOrLandmark:Optional[EntityOrItsNameOrLandmark]=None, mirrorAxis:AxisOrItsIndexOrItsName="x", mirror:bool=False, circularPatternInstanceCount:'int'=1, circularPatternInstanceSeparation:AngleOrItsFloatOrStringValue=0.0, circularPatternInstanceAxis:AxisOrItsIndexOrItsName="z", circularPatternAboutEntityOrLandmark:Optional[EntityOrItsNameOrLandmark]=None, linearPatternInstanceCount:'int'=1, linearPatternInstanceSeparation:DimensionOrItsFloatOrStringValue=0.0, linearPatternInstanceAxis:AxisOrItsIndexOrItsName="x", linearPattern2ndInstanceCount:'int'=1, linearPattern2ndInstanceSeparation:DimensionOrItsFloatOrStringValue=0.0, linearPattern2ndInstanceAxis:AxisOrItsIndexOrItsName="y"):
         '''
         Create a hole.
@@ -685,16 +695,6 @@ class Sketch(Entity,metaclass=ABCMeta):
         
 
     @abstractmethod
-    def thicken(self, radius:DimensionOrItsFloatOrStringValue) -> 'Part':
-        '''
-        Uniformly add a wall around a sketch.
-        '''
-        
-        print("thicken is called in an abstract method. Please override this method.")
-        raise NotImplementedError()
-        
-
-    @abstractmethod
     def extrude(self, length:DimensionOrItsFloatOrStringValue) -> 'Part':
         '''
         Extrude a curve by a specified length. Returns a Part type.
@@ -712,6 +712,16 @@ class Sketch(Entity,metaclass=ABCMeta):
         
         print("sweep is called in an abstract method. Please override this method.")
         raise NotImplementedError()
+        
+
+    @abstractmethod
+    def offset(self, radius:DimensionOrItsFloatOrStringValue):
+        '''
+        Uniformly add a wall around a Sketch.
+        '''
+        
+        print("offset is called in an abstract method. Please override this method.")
+        return self
         
 
     @abstractmethod

--- a/CodeToCAD/CodeToCADProvider.py
+++ b/CodeToCAD/CodeToCADProvider.py
@@ -269,6 +269,11 @@ class Part(Entity,CodeToCADInterface.Part):
         return self
         
 
+    def thicken(self, radius:DimensionOrItsFloatOrStringValue):
+        
+        return self
+        
+
     def hole(self, holeLandmark:LandmarkOrItsName, radius:DimensionOrItsFloatOrStringValue, depth:DimensionOrItsFloatOrStringValue, normalAxis:AxisOrItsIndexOrItsName="z", flipAxis:bool=False, initialRotationX:AngleOrItsFloatOrStringValue=0.0, initialRotationY:AngleOrItsFloatOrStringValue=0.0, initialRotationZ:AngleOrItsFloatOrStringValue=0.0, mirrorAboutEntityOrLandmark:Optional[EntityOrItsNameOrLandmark]=None, mirrorAxis:AxisOrItsIndexOrItsName="x", mirror:bool=False, circularPatternInstanceCount:'int'=1, circularPatternInstanceSeparation:AngleOrItsFloatOrStringValue=0.0, circularPatternInstanceAxis:AxisOrItsIndexOrItsName="z", circularPatternAboutEntityOrLandmark:Optional[EntityOrItsNameOrLandmark]=None, linearPatternInstanceCount:'int'=1, linearPatternInstanceSeparation:DimensionOrItsFloatOrStringValue=0.0, linearPatternInstanceAxis:AxisOrItsIndexOrItsName="x", linearPattern2ndInstanceCount:'int'=1, linearPattern2ndInstanceSeparation:DimensionOrItsFloatOrStringValue=0.0, linearPattern2ndInstanceAxis:AxisOrItsIndexOrItsName="y"):
         
         return self
@@ -351,11 +356,6 @@ class Sketch(Entity,CodeToCADInterface.Sketch):
         raise NotImplementedError()
         
 
-    def thicken(self, radius:DimensionOrItsFloatOrStringValue) -> 'Part':
-        
-        raise NotImplementedError()
-        
-
     def extrude(self, length:DimensionOrItsFloatOrStringValue) -> 'Part':
         
         raise NotImplementedError()
@@ -364,6 +364,11 @@ class Sketch(Entity,CodeToCADInterface.Sketch):
     def sweep(self, profileNameOrInstance:SketchOrItsName, fillCap:bool=True) -> 'Part':
         
         raise NotImplementedError()
+        
+
+    def offset(self, radius:DimensionOrItsFloatOrStringValue):
+        
+        return self
         
 
     def profile(self, profileCurveName:str):

--- a/CodeToCAD/TestCodeToCADProvider.py
+++ b/CodeToCAD/TestCodeToCADProvider.py
@@ -1,4 +1,4 @@
-# THIS IS AN AUTO-GENERATE FILE. 
+# THIS IS AN AUTO-GENERATE FILE.
 # DO NOT EDIT MANUALLY.
 # Please run development/capabilitiesJsonToPython/capabilitiesToPy.sh to generate this file.
 # Copy this file and remove this header to create a new CodeToCAD Provider Test.
@@ -10,8 +10,9 @@ from CodeToCAD import *
 import CodeToCAD.CodeToCADInterface as CodeToCADInterface
 import CodeToCAD.utilities as Utilities
 from CodeToCAD.utilities import (Angle, BoundaryBox, CurveTypes, Dimension,
-                            Dimensions, Point, center, createUUIDLikeId,
-                            getAbsoluteFilepath, getFilename, max, min)
+                                 Dimensions, Point, center, createUUIDLikeId,
+                                 getAbsoluteFilepath, getFilename, max, min)
+
 
 class TestProviderCase(unittest.TestCase):
 
@@ -19,1473 +20,1338 @@ class TestProviderCase(unittest.TestCase):
         # inject provider?
         super().setUp()
 
+
 class TestEntity(TestProviderCase):
-    
-    
+
     @unittest.skip
     def test_createFromFile(self):
-        instance = Part("name","description")
+        instance = Part("name", "description")
 
-        value = instance.createFromFile("filePath","fileType")
+        value = instance.createFromFile("filePath", "fileType")
 
-        
         assert value.isExists(), "Create method failed."
-        
+
     @unittest.skip
     def test_isExists(self):
-        instance = Part("name","description")
+        instance = Part("name", "description")
 
         value = instance.isExists("")
 
-        
         assert value, "Get method failed."
-        
+
     @unittest.skip
     def test_rename(self):
-        instance = Part("name","description")
+        instance = Part("name", "description")
 
-        value = instance.rename("newName","renamelinkedEntitiesAndLandmarks")
+        value = instance.rename("newName", "renamelinkedEntitiesAndLandmarks")
 
-        
         assert value, "Modify method failed."
-        
+
     @unittest.skip
     def test_delete(self):
-        instance = Part("name","description")
+        instance = Part("name", "description")
 
         value = instance.delete("removeChildren")
 
-        
     @unittest.skip
     def test_isVisible(self):
-        instance = Part("name","description")
+        instance = Part("name", "description")
 
         value = instance.isVisible("")
 
-        
         assert value, "Get method failed."
-        
+
     @unittest.skip
     def test_setVisible(self):
-        instance = Part("name","description")
+        instance = Part("name", "description")
 
         value = instance.setVisible("isVisible")
 
-        
     @unittest.skip
     def test_apply(self):
-        instance = Part("name","description")
+        instance = Part("name", "description")
 
-        value = instance.apply("rotation","scale","location","modifiers")
+        value = instance.apply("rotation", "scale", "location", "modifiers")
 
-        
         assert value, "Modify method failed."
-        
+
     @unittest.skip
     def test_getNativeInstance(self):
-        instance = Part("name","description")
+        instance = Part("name", "description")
 
         value = instance.getNativeInstance("")
 
-        
         assert value, "Get method failed."
-        
+
     @unittest.skip
     def test_getLocationWorld(self):
-        instance = Part("name","description")
+        instance = Part("name", "description")
 
         value = instance.getLocationWorld("")
 
-        
         assert value, "Get method failed."
-        
+
     @unittest.skip
     def test_getLocationLocal(self):
-        instance = Part("name","description")
+        instance = Part("name", "description")
 
         value = instance.getLocationLocal("")
 
-        
         assert value, "Get method failed."
-        
+
     @unittest.skip
     def test_select(self):
-        instance = Part("name","description")
+        instance = Part("name", "description")
 
         value = instance.select("")
 
-        
     @unittest.skip
     def test_export(self):
-        instance = Part("name","description")
+        instance = Part("name", "description")
 
-        value = instance.export("filePath","overwrite","scale")
+        value = instance.export("filePath", "overwrite", "scale")
 
-        
     @unittest.skip
     def test_mirror(self):
-        instance = Part("name","description")
+        instance = Part("name", "description")
 
-        value = instance.mirror("mirrorAcrossEntityOrLandmark","axis","resultingMirroredEntityName")
+        value = instance.mirror(
+            "mirrorAcrossEntityOrLandmark", "axis", "resultingMirroredEntityName")
 
-        
         assert value.isExists(), "Create method failed."
-        
+
     @unittest.skip
     def test_linearPattern(self):
-        instance = Part("name","description")
+        instance = Part("name", "description")
 
-        value = instance.linearPattern("instanceCount","offset","directionAxis")
+        value = instance.linearPattern(
+            "instanceCount", "offset", "directionAxis")
 
-        
         assert value, "Modify method failed."
-        
+
     @unittest.skip
     def test_circularPattern(self):
-        instance = Part("name","description")
+        instance = Part("name", "description")
 
-        value = instance.circularPattern("instanceCount","separationAngle","centerEntityOrLandmark","normalDirectionAxis")
+        value = instance.circularPattern(
+            "instanceCount", "separationAngle", "centerEntityOrLandmark", "normalDirectionAxis")
 
-        
         assert value, "Modify method failed."
-        
+
     @unittest.skip
     def test_translateXYZ(self):
-        instance = Part("name","description")
+        instance = Part("name", "description")
 
-        value = instance.translateXYZ("x","y","z")
+        value = instance.translateXYZ("x", "y", "z")
 
-        
         assert value, "Modify method failed."
-        
+
     @unittest.skip
     def test_translateX(self):
-        instance = Part("name","description")
+        instance = Part("name", "description")
 
         value = instance.translateX("amount")
 
-        
         assert value, "Modify method failed."
-        
+
     @unittest.skip
     def test_translateY(self):
-        instance = Part("name","description")
+        instance = Part("name", "description")
 
         value = instance.translateY("amount")
 
-        
         assert value, "Modify method failed."
-        
+
     @unittest.skip
     def test_translateZ(self):
-        instance = Part("name","description")
+        instance = Part("name", "description")
 
         value = instance.translateZ("amount")
 
-        
         assert value, "Modify method failed."
-        
+
     @unittest.skip
     def test_scaleXYZ(self):
-        instance = Part("name","description")
+        instance = Part("name", "description")
 
-        value = instance.scaleXYZ("x","y","z")
+        value = instance.scaleXYZ("x", "y", "z")
 
-        
         assert value, "Modify method failed."
-        
+
     @unittest.skip
     def test_scaleX(self):
-        instance = Part("name","description")
+        instance = Part("name", "description")
 
         value = instance.scaleX("scale")
 
-        
         assert value, "Modify method failed."
-        
+
     @unittest.skip
     def test_scaleY(self):
-        instance = Part("name","description")
+        instance = Part("name", "description")
 
         value = instance.scaleY("scale")
 
-        
         assert value, "Modify method failed."
-        
+
     @unittest.skip
     def test_scaleZ(self):
-        instance = Part("name","description")
+        instance = Part("name", "description")
 
         value = instance.scaleZ("scale")
 
-        
         assert value, "Modify method failed."
-        
+
     @unittest.skip
     def test_scaleXByFactor(self):
-        instance = Part("name","description")
+        instance = Part("name", "description")
 
         value = instance.scaleXByFactor("scaleFactor")
 
-        
         assert value, "Modify method failed."
-        
+
     @unittest.skip
     def test_scaleYByFactor(self):
-        instance = Part("name","description")
+        instance = Part("name", "description")
 
         value = instance.scaleYByFactor("scaleFactor")
 
-        
         assert value, "Modify method failed."
-        
+
     @unittest.skip
     def test_scaleZByFactor(self):
-        instance = Part("name","description")
+        instance = Part("name", "description")
 
         value = instance.scaleZByFactor("scaleFactor")
 
-        
         assert value, "Modify method failed."
-        
+
     @unittest.skip
     def test_scaleKeepAspectRatio(self):
-        instance = Part("name","description")
+        instance = Part("name", "description")
 
-        value = instance.scaleKeepAspectRatio("scale","axis")
+        value = instance.scaleKeepAspectRatio("scale", "axis")
 
-        
         assert value, "Modify method failed."
-        
+
     @unittest.skip
     def test_rotateXYZ(self):
-        instance = Part("name","description")
+        instance = Part("name", "description")
 
-        value = instance.rotateXYZ("x","y","z")
+        value = instance.rotateXYZ("x", "y", "z")
 
-        
         assert value, "Modify method failed."
-        
+
     @unittest.skip
     def test_rotateX(self):
-        instance = Part("name","description")
+        instance = Part("name", "description")
 
         value = instance.rotateX("rotation")
 
-        
         assert value, "Modify method failed."
-        
+
     @unittest.skip
     def test_rotateY(self):
-        instance = Part("name","description")
+        instance = Part("name", "description")
 
         value = instance.rotateY("rotation")
 
-        
         assert value, "Modify method failed."
-        
+
     @unittest.skip
     def test_rotateZ(self):
-        instance = Part("name","description")
+        instance = Part("name", "description")
 
         value = instance.rotateZ("rotation")
 
-        
         assert value, "Modify method failed."
-        
+
     @unittest.skip
     def test_twist(self):
-        instance = Part("name","description")
+        instance = Part("name", "description")
 
-        value = instance.twist("angle","screwPitch","interations","axis")
+        value = instance.twist("angle", "screwPitch", "interations", "axis")
 
-        
         assert value, "Modify method failed."
-        
+
     @unittest.skip
     def test_remesh(self):
-        instance = Part("name","description")
+        instance = Part("name", "description")
 
-        value = instance.remesh("strategy","amount")
+        value = instance.remesh("strategy", "amount")
 
-        
         assert value, "Modify method failed."
-        
+
     @unittest.skip
     def test_createLandmark(self):
-        instance = Part("name","description")
+        instance = Part("name", "description")
 
-        value = instance.createLandmark("landmarkName","x","y","z")
+        value = instance.createLandmark("landmarkName", "x", "y", "z")
 
-        
         assert value, "Get method failed."
-        
+
     @unittest.skip
     def test_getBoundingBox(self):
-        instance = Part("name","description")
+        instance = Part("name", "description")
 
         value = instance.getBoundingBox("")
 
-        
         assert value, "Get method failed."
-        
+
     @unittest.skip
     def test_getDimensions(self):
-        instance = Part("name","description")
+        instance = Part("name", "description")
 
         value = instance.getDimensions("")
 
-        
         assert value, "Get method failed."
-        
+
     @unittest.skip
     def test_getLandmark(self):
-        instance = Part("name","description")
+        instance = Part("name", "description")
 
         value = instance.getLandmark("landmarkName")
 
-        
         assert value, "Get method failed."
-        
+
+
 class TestPart(TestProviderCase):
-    
+
     @unittest.skip
     def test_createCube(self):
         instance = Part("")
 
-        value = instance.createCube("width","length","height","keywordArguments")
+        value = instance.createCube(
+            "width", "length", "height", "keywordArguments")
 
-        
         assert value.isExists(), "Create method failed."
-        
+
     @unittest.skip
     def test_createCone(self):
         instance = Part("")
 
-        value = instance.createCone("radius","height","draftRadius","keywordArguments")
+        value = instance.createCone(
+            "radius", "height", "draftRadius", "keywordArguments")
 
-        
         assert value.isExists(), "Create method failed."
-        
+
     @unittest.skip
     def test_createCylinder(self):
         instance = Part("")
 
-        value = instance.createCylinder("radius","height","keywordArguments")
+        value = instance.createCylinder("radius", "height", "keywordArguments")
 
-        
         assert value.isExists(), "Create method failed."
-        
+
     @unittest.skip
     def test_createTorus(self):
         instance = Part("")
 
-        value = instance.createTorus("innerRadius","outerRadius","keywordArguments")
+        value = instance.createTorus(
+            "innerRadius", "outerRadius", "keywordArguments")
 
-        
         assert value.isExists(), "Create method failed."
-        
+
     @unittest.skip
     def test_createSphere(self):
         instance = Part("")
 
-        value = instance.createSphere("radius","keywordArguments")
+        value = instance.createSphere("radius", "keywordArguments")
 
-        
         assert value.isExists(), "Create method failed."
-        
+
     @unittest.skip
     def test_createGear(self):
         instance = Part("")
 
-        value = instance.createGear("outerRadius","addendum","innerRadius","dedendum","height","pressureAngle","numberOfTeeth","skewAngle","conicalAngle","crownAngle","keywordArguments")
+        value = instance.createGear("outerRadius", "addendum", "innerRadius", "dedendum", "height",
+                                    "pressureAngle", "numberOfTeeth", "skewAngle", "conicalAngle", "crownAngle", "keywordArguments")
 
-        
         assert value.isExists(), "Create method failed."
-        
+
     @unittest.skip
     def test_clone(self):
         instance = Part("")
 
-        value = instance.clone("newName","copyLandmarks")
+        value = instance.clone("newName", "copyLandmarks")
 
-        
         assert value, "Get method failed."
-        
+
     @unittest.skip
     def test_loft(self):
         instance = Part("")
 
-        value = instance.loft("Landmark1","Landmark2")
+        value = instance.loft("Landmark1", "Landmark2")
 
-        
         assert value.isExists(), "Create method failed."
-        
+
     @unittest.skip
     def test_union(self):
         instance = Part("")
 
-        value = instance.union("withPart","deleteAfterUnion","isTransferLandmarks")
+        value = instance.union(
+            "withPart", "deleteAfterUnion", "isTransferLandmarks")
 
-        
         assert value, "Modify method failed."
-        
+
     @unittest.skip
     def test_subtract(self):
         instance = Part("")
 
-        value = instance.subtract("withPart","deleteAfterSubtract","isTransferLandmarks")
+        value = instance.subtract(
+            "withPart", "deleteAfterSubtract", "isTransferLandmarks")
 
-        
         assert value, "Modify method failed."
-        
+
     @unittest.skip
     def test_intersect(self):
         instance = Part("")
 
-        value = instance.intersect("withPart","deleteAfterIntersect","isTransferLandmarks")
+        value = instance.intersect(
+            "withPart", "deleteAfterIntersect", "isTransferLandmarks")
 
-        
         assert value, "Modify method failed."
-        
+
     @unittest.skip
     def test_hollow(self):
         instance = Part("")
 
-        value = instance.hollow("thicknessX","thicknessY","thicknessZ","startAxis","flipAxis")
+        value = instance.hollow(
+            "thicknessX", "thicknessY", "thicknessZ", "startAxis", "flipAxis")
 
-        
         assert value, "Modify method failed."
-        
+
+    @unittest.skip
+    def test_thicken(self):
+        instance = Part("")
+
+        value = instance.thicken("radius")
+
+        assert value, "Modify method failed."
+
     @unittest.skip
     def test_hole(self):
         instance = Part("")
 
-        value = instance.hole("holeLandmark","radius","depth","normalAxis","flipAxis","initialRotationX","initialRotationY","initialRotationZ","mirrorAboutEntityOrLandmark","mirrorAxis","mirror","circularPatternInstanceCount","circularPatternInstanceSeparation","circularPatternInstanceAxis","circularPatternAboutEntityOrLandmark","linearPatternInstanceCount","linearPatternInstanceSeparation","linearPatternInstanceAxis","linearPattern2ndInstanceCount","linearPattern2ndInstanceSeparation","linearPattern2ndInstanceAxis")
+        value = instance.hole("holeLandmark", "radius", "depth", "normalAxis", "flipAxis", "initialRotationX", "initialRotationY", "initialRotationZ", "mirrorAboutEntityOrLandmark", "mirrorAxis", "mirror", "circularPatternInstanceCount", "circularPatternInstanceSeparation",
+                              "circularPatternInstanceAxis", "circularPatternAboutEntityOrLandmark", "linearPatternInstanceCount", "linearPatternInstanceSeparation", "linearPatternInstanceAxis", "linearPattern2ndInstanceCount", "linearPattern2ndInstanceSeparation", "linearPattern2ndInstanceAxis")
 
-        
         assert value, "Modify method failed."
-        
+
     @unittest.skip
     def test_setMaterial(self):
         instance = Part("")
 
         value = instance.setMaterial("materialName")
 
-        
         assert value, "Modify method failed."
-        
+
     @unittest.skip
     def test_isCollidingWithPart(self):
         instance = Part("")
 
         value = instance.isCollidingWithPart("otherPart")
 
-        
         assert value, "Get method failed."
-        
+
     @unittest.skip
     def test_filletAllEdges(self):
         instance = Part("")
 
-        value = instance.filletAllEdges("radius","useWidth")
+        value = instance.filletAllEdges("radius", "useWidth")
 
-        
         assert value, "Modify method failed."
-        
+
     @unittest.skip
     def test_filletEdges(self):
         instance = Part("")
 
-        value = instance.filletEdges("radius","landmarksNearEdges","useWidth")
+        value = instance.filletEdges(
+            "radius", "landmarksNearEdges", "useWidth")
 
-        
         assert value, "Modify method failed."
-        
+
     @unittest.skip
     def test_filletFaces(self):
         instance = Part("")
 
-        value = instance.filletFaces("radius","landmarksNearFaces","useWidth")
+        value = instance.filletFaces(
+            "radius", "landmarksNearFaces", "useWidth")
 
-        
         assert value, "Modify method failed."
-        
+
     @unittest.skip
     def test_chamferAllEdges(self):
         instance = Part("")
 
         value = instance.chamferAllEdges("radius")
 
-        
         assert value, "Modify method failed."
-        
+
     @unittest.skip
     def test_chamferEdges(self):
         instance = Part("")
 
-        value = instance.chamferEdges("radius","landmarksNearEdges")
+        value = instance.chamferEdges("radius", "landmarksNearEdges")
 
-        
         assert value, "Modify method failed."
-        
+
     @unittest.skip
     def test_chamferFaces(self):
         instance = Part("")
 
-        value = instance.chamferFaces("radius","landmarksNearFaces")
+        value = instance.chamferFaces("radius", "landmarksNearFaces")
 
-        
         assert value, "Modify method failed."
-        
+
     @unittest.skip
     def test_selectVertexNearLandmark(self):
         instance = Part("")
 
         value = instance.selectVertexNearLandmark("landmarkName")
 
-        
     @unittest.skip
     def test_selectEdgeNearLandmark(self):
         instance = Part("")
 
         value = instance.selectEdgeNearLandmark("landmarkName")
 
-        
     @unittest.skip
     def test_selectFaceNearLandmark(self):
         instance = Part("")
 
         value = instance.selectFaceNearLandmark("landmarkName")
 
-        
+
 class TestSketch(TestProviderCase):
-    
-    
+
     @unittest.skip
     def test_clone(self):
-        instance = Sketch("name","curveType","description")
+        instance = Sketch("name", "curveType", "description")
 
-        value = instance.clone("newName","copyLandmarks")
+        value = instance.clone("newName", "copyLandmarks")
 
-        
         assert value, "Get method failed."
-        
+
     @unittest.skip
     def test_revolve(self):
-        instance = Sketch("name","curveType","description")
+        instance = Sketch("name", "curveType", "description")
 
-        value = instance.revolve("angle","aboutEntityOrLandmark","axis")
+        value = instance.revolve("angle", "aboutEntityOrLandmark", "axis")
 
-        
         assert value, "Get method failed."
-        
-    @unittest.skip
-    def test_thicken(self):
-        instance = Sketch("name","curveType","description")
 
-        value = instance.thicken("radius")
-
-        
-        assert value, "Get method failed."
-        
     @unittest.skip
     def test_extrude(self):
-        instance = Sketch("name","curveType","description")
+        instance = Sketch("name", "curveType", "description")
 
         value = instance.extrude("length")
 
-        
         assert value, "Get method failed."
-        
+
     @unittest.skip
     def test_sweep(self):
-        instance = Sketch("name","curveType","description")
+        instance = Sketch("name", "curveType", "description")
 
-        value = instance.sweep("profileNameOrInstance","fillCap")
+        value = instance.sweep("profileNameOrInstance", "fillCap")
 
-        
         assert value, "Get method failed."
-        
+
+    @unittest.skip
+    def test_offset(self):
+        instance = Sketch("name", "curveType", "description")
+
+        value = instance.offset("radius")
+
+        assert value, "Modify method failed."
+
     @unittest.skip
     def test_profile(self):
-        instance = Sketch("name","curveType","description")
+        instance = Sketch("name", "curveType", "description")
 
         value = instance.profile("profileCurveName")
 
-        
         assert value, "Modify method failed."
-        
+
     @unittest.skip
     def test_createText(self):
-        instance = Sketch("name","curveType","description")
+        instance = Sketch("name", "curveType", "description")
 
-        value = instance.createText("text","fontSize","bold","italic","underlined","characterSpacing","wordSpacing","lineSpacing","fontFilePath")
+        value = instance.createText("text", "fontSize", "bold", "italic", "underlined",
+                                    "characterSpacing", "wordSpacing", "lineSpacing", "fontFilePath")
 
-        
         assert value.isExists(), "Create method failed."
-        
+
     @unittest.skip
     def test_createFromVertices(self):
-        instance = Sketch("name","curveType","description")
+        instance = Sketch("name", "curveType", "description")
 
-        value = instance.createFromVertices("coordinates","interpolation")
+        value = instance.createFromVertices("coordinates", "interpolation")
 
-        
         assert value.isExists(), "Create method failed."
-        
+
     @unittest.skip
     def test_createPoint(self):
-        instance = Sketch("name","curveType","description")
+        instance = Sketch("name", "curveType", "description")
 
         value = instance.createPoint("coordinate")
 
-        
         assert value.isExists(), "Create method failed."
-        
+
     @unittest.skip
     def test_createLine(self):
-        instance = Sketch("name","curveType","description")
+        instance = Sketch("name", "curveType", "description")
 
-        value = instance.createLine("length","angleX","angleY","symmetric")
+        value = instance.createLine("length", "angleX", "angleY", "symmetric")
 
-        
         assert value.isExists(), "Create method failed."
-        
+
     @unittest.skip
     def test_createLineBetweenPoints(self):
-        instance = Sketch("name","curveType","description")
+        instance = Sketch("name", "curveType", "description")
 
-        value = instance.createLineBetweenPoints("endAt","startAt")
+        value = instance.createLineBetweenPoints("endAt", "startAt")
 
-        
         assert value.isExists(), "Create method failed."
-        
+
     @unittest.skip
     def test_createCircle(self):
-        instance = Sketch("name","curveType","description")
+        instance = Sketch("name", "curveType", "description")
 
         value = instance.createCircle("radius")
 
-        
         assert value.isExists(), "Create method failed."
-        
+
     @unittest.skip
     def test_createEllipse(self):
-        instance = Sketch("name","curveType","description")
+        instance = Sketch("name", "curveType", "description")
 
-        value = instance.createEllipse("radiusA","radiusB")
+        value = instance.createEllipse("radiusA", "radiusB")
 
-        
         assert value.isExists(), "Create method failed."
-        
+
     @unittest.skip
     def test_createArc(self):
-        instance = Sketch("name","curveType","description")
+        instance = Sketch("name", "curveType", "description")
 
-        value = instance.createArc("radius","angle")
+        value = instance.createArc("radius", "angle")
 
-        
         assert value.isExists(), "Create method failed."
-        
+
     @unittest.skip
     def test_createArcBetweenThreePoints(self):
-        instance = Sketch("name","curveType","description")
+        instance = Sketch("name", "curveType", "description")
 
-        value = instance.createArcBetweenThreePoints("pointA","pointB","centerPoint")
+        value = instance.createArcBetweenThreePoints(
+            "pointA", "pointB", "centerPoint")
 
-        
         assert value.isExists(), "Create method failed."
-        
+
     @unittest.skip
     def test_createSegment(self):
-        instance = Sketch("name","curveType","description")
+        instance = Sketch("name", "curveType", "description")
 
-        value = instance.createSegment("innerRadius","outerRadius","angle")
+        value = instance.createSegment("innerRadius", "outerRadius", "angle")
 
-        
         assert value.isExists(), "Create method failed."
-        
+
     @unittest.skip
     def test_createRectangle(self):
-        instance = Sketch("name","curveType","description")
+        instance = Sketch("name", "curveType", "description")
 
-        value = instance.createRectangle("length","width")
+        value = instance.createRectangle("length", "width")
 
-        
         assert value.isExists(), "Create method failed."
-        
+
     @unittest.skip
     def test_createPolygon(self):
-        instance = Sketch("name","curveType","description")
+        instance = Sketch("name", "curveType", "description")
 
-        value = instance.createPolygon("numberOfSides","length","width")
+        value = instance.createPolygon("numberOfSides", "length", "width")
 
-        
         assert value.isExists(), "Create method failed."
-        
+
     @unittest.skip
     def test_createTrapezoid(self):
-        instance = Sketch("name","curveType","description")
+        instance = Sketch("name", "curveType", "description")
 
-        value = instance.createTrapezoid("lengthUpper","lengthLower","height")
+        value = instance.createTrapezoid(
+            "lengthUpper", "lengthLower", "height")
 
-        
         assert value.isExists(), "Create method failed."
-        
+
     @unittest.skip
     def test_createSpiral(self):
-        instance = Sketch("name","curveType","description")
+        instance = Sketch("name", "curveType", "description")
 
-        value = instance.createSpiral("numberOfTurns","height","radius","isClockwise","radiusEnd")
+        value = instance.createSpiral(
+            "numberOfTurns", "height", "radius", "isClockwise", "radiusEnd")
 
-        
         assert value.isExists(), "Create method failed."
-        
+
+
 class TestLandmark(TestProviderCase):
-    
-    
+
     @unittest.skip
     def test_getLandmarkEntityName(self):
-        instance = Landmark("name","parentEntity","description")
+        instance = Landmark("name", "parentEntity", "description")
 
         value = instance.getLandmarkEntityName("")
 
-        
         assert value, "Get method failed."
-        
+
     @unittest.skip
     def test_getParentEntity(self):
-        instance = Landmark("name","parentEntity","description")
+        instance = Landmark("name", "parentEntity", "description")
 
         value = instance.getParentEntity("")
 
-        
         assert value, "Get method failed."
-        
+
     @unittest.skip
     def test_isExists(self):
-        instance = Landmark("name","parentEntity","description")
+        instance = Landmark("name", "parentEntity", "description")
 
         value = instance.isExists("")
 
-        
         assert value, "Get method failed."
-        
+
     @unittest.skip
     def test_rename(self):
-        instance = Landmark("name","parentEntity","description")
+        instance = Landmark("name", "parentEntity", "description")
 
         value = instance.rename("newName")
 
-        
         assert value, "Modify method failed."
-        
+
     @unittest.skip
     def test_delete(self):
-        instance = Landmark("name","parentEntity","description")
+        instance = Landmark("name", "parentEntity", "description")
 
         value = instance.delete("")
 
-        
     @unittest.skip
     def test_isVisible(self):
-        instance = Landmark("name","parentEntity","description")
+        instance = Landmark("name", "parentEntity", "description")
 
         value = instance.isVisible("")
 
-        
         assert value, "Get method failed."
-        
+
     @unittest.skip
     def test_setVisible(self):
-        instance = Landmark("name","parentEntity","description")
+        instance = Landmark("name", "parentEntity", "description")
 
         value = instance.setVisible("isVisible")
 
-        
     @unittest.skip
     def test_getNativeInstance(self):
-        instance = Landmark("name","parentEntity","description")
+        instance = Landmark("name", "parentEntity", "description")
 
         value = instance.getNativeInstance("")
 
-        
         assert value, "Get method failed."
-        
+
     @unittest.skip
     def test_getLocationWorld(self):
-        instance = Landmark("name","parentEntity","description")
+        instance = Landmark("name", "parentEntity", "description")
 
         value = instance.getLocationWorld("")
 
-        
         assert value, "Get method failed."
-        
+
     @unittest.skip
     def test_getLocationLocal(self):
-        instance = Landmark("name","parentEntity","description")
+        instance = Landmark("name", "parentEntity", "description")
 
         value = instance.getLocationLocal("")
 
-        
         assert value, "Get method failed."
-        
+
     @unittest.skip
     def test_select(self):
-        instance = Landmark("name","parentEntity","description")
+        instance = Landmark("name", "parentEntity", "description")
 
         value = instance.select("")
 
-        
+
 class TestJoint(TestProviderCase):
-    
-    
+
     @unittest.skip
     def test_translateLandmarkOntoAnother(self):
-        instance = Joint("entity1","entity2")
+        instance = Joint("entity1", "entity2")
 
         value = instance.translateLandmarkOntoAnother("")
 
-        
         assert value, "Modify method failed."
-        
+
     @unittest.skip
     def test_pivot(self):
-        instance = Joint("entity1","entity2")
+        instance = Joint("entity1", "entity2")
 
         value = instance.pivot("")
 
-        
         assert value, "Modify method failed."
-        
+
     @unittest.skip
     def test_gearRatio(self):
-        instance = Joint("entity1","entity2")
+        instance = Joint("entity1", "entity2")
 
         value = instance.gearRatio("ratio")
 
-        
         assert value, "Modify method failed."
-        
+
     @unittest.skip
     def test_limitLocationXYZ(self):
-        instance = Joint("entity1","entity2")
+        instance = Joint("entity1", "entity2")
 
-        value = instance.limitLocationXYZ("x","y","z")
+        value = instance.limitLocationXYZ("x", "y", "z")
 
-        
         assert value, "Modify method failed."
-        
+
     @unittest.skip
     def test_limitLocationX(self):
-        instance = Joint("entity1","entity2")
+        instance = Joint("entity1", "entity2")
 
-        value = instance.limitLocationX("min","max")
+        value = instance.limitLocationX("min", "max")
 
-        
         assert value, "Modify method failed."
-        
+
     @unittest.skip
     def test_limitLocationY(self):
-        instance = Joint("entity1","entity2")
+        instance = Joint("entity1", "entity2")
 
-        value = instance.limitLocationY("min","max")
+        value = instance.limitLocationY("min", "max")
 
-        
         assert value, "Modify method failed."
-        
+
     @unittest.skip
     def test_limitLocationZ(self):
-        instance = Joint("entity1","entity2")
+        instance = Joint("entity1", "entity2")
 
-        value = instance.limitLocationZ("min","max")
+        value = instance.limitLocationZ("min", "max")
 
-        
         assert value, "Modify method failed."
-        
+
     @unittest.skip
     def test_limitRotationXYZ(self):
-        instance = Joint("entity1","entity2")
+        instance = Joint("entity1", "entity2")
 
-        value = instance.limitRotationXYZ("x","y","z")
+        value = instance.limitRotationXYZ("x", "y", "z")
 
-        
         assert value, "Modify method failed."
-        
+
     @unittest.skip
     def test_limitRotationX(self):
-        instance = Joint("entity1","entity2")
+        instance = Joint("entity1", "entity2")
 
-        value = instance.limitRotationX("min","max")
+        value = instance.limitRotationX("min", "max")
 
-        
         assert value, "Modify method failed."
-        
+
     @unittest.skip
     def test_limitRotationY(self):
-        instance = Joint("entity1","entity2")
+        instance = Joint("entity1", "entity2")
 
-        value = instance.limitRotationY("min","max")
+        value = instance.limitRotationY("min", "max")
 
-        
         assert value, "Modify method failed."
-        
+
     @unittest.skip
     def test_limitRotationZ(self):
-        instance = Joint("entity1","entity2")
+        instance = Joint("entity1", "entity2")
 
-        value = instance.limitRotationZ("min","max")
+        value = instance.limitRotationZ("min", "max")
 
-        
         assert value, "Modify method failed."
-        
+
+
 class TestMaterial(TestProviderCase):
-    
-    
+
     @unittest.skip
     def test_assignToPart(self):
-        instance = Material("name","description")
+        instance = Material("name", "description")
 
         value = instance.assignToPart("partNameOrInstance")
 
-        
         assert value, "Modify method failed."
-        
+
     @unittest.skip
     def test_setColor(self):
-        instance = Material("name","description")
+        instance = Material("name", "description")
 
-        value = instance.setColor("rValue","gValue","bValue","aValue")
+        value = instance.setColor("rValue", "gValue", "bValue", "aValue")
 
-        
         assert value, "Modify method failed."
-        
+
     @unittest.skip
     def test_setReflectivity(self):
-        instance = Material("name","description")
+        instance = Material("name", "description")
 
         value = instance.setReflectivity("reflectivity")
 
-        
         assert value, "Modify method failed."
-        
+
     @unittest.skip
     def test_setRoughness(self):
-        instance = Material("name","description")
+        instance = Material("name", "description")
 
         value = instance.setRoughness("roughness")
 
-        
         assert value, "Modify method failed."
-        
+
     @unittest.skip
     def test_addImageTexture(self):
-        instance = Material("name","description")
+        instance = Material("name", "description")
 
         value = instance.addImageTexture("imageFilePath")
 
-        
         assert value, "Modify method failed."
-        
+
+
 class TestAnimation(TestProviderCase):
-    
-    
-    
+
     @unittest.skip
     def test_setFrameStart(self):
         instance = Animation("")
 
         value = instance.setFrameStart("frameNumber")
 
-        
         assert value, "Modify method failed."
-        
+
     @unittest.skip
     def test_setFrameEnd(self):
         instance = Animation("")
 
         value = instance.setFrameEnd("frameNumber")
 
-        
         assert value, "Modify method failed."
-        
+
     @unittest.skip
     def test_setFrameCurrent(self):
         instance = Animation("")
 
         value = instance.setFrameCurrent("frameNumber")
 
-        
         assert value, "Modify method failed."
-        
+
     @unittest.skip
     def test_createKeyFrameLocation(self):
         instance = Animation("")
 
-        value = instance.createKeyFrameLocation("entity","frameNumber")
+        value = instance.createKeyFrameLocation("entity", "frameNumber")
 
-        
         assert value, "Modify method failed."
-        
+
     @unittest.skip
     def test_createKeyFrameRotation(self):
         instance = Animation("")
 
-        value = instance.createKeyFrameRotation("entity","frameNumber")
+        value = instance.createKeyFrameRotation("entity", "frameNumber")
 
-        
         assert value, "Modify method failed."
-        
+
+
 class TestLight(TestProviderCase):
-    
-    
+
     @unittest.skip
     def test_setColor(self):
-        instance = Light("name","description")
+        instance = Light("name", "description")
 
-        value = instance.setColor("rValue","gValue","bValue")
+        value = instance.setColor("rValue", "gValue", "bValue")
 
-        
         assert value, "Modify method failed."
-        
+
     @unittest.skip
     def test_createSun(self):
-        instance = Light("name","description")
+        instance = Light("name", "description")
 
         value = instance.createSun("energyLevel")
 
-        
         assert value.isExists(), "Create method failed."
-        
+
     @unittest.skip
     def test_createSpot(self):
-        instance = Light("name","description")
+        instance = Light("name", "description")
 
         value = instance.createSpot("energyLevel")
 
-        
         assert value.isExists(), "Create method failed."
-        
+
     @unittest.skip
     def test_createPoint(self):
-        instance = Light("name","description")
+        instance = Light("name", "description")
 
         value = instance.createPoint("energyLevel")
 
-        
         assert value.isExists(), "Create method failed."
-        
+
     @unittest.skip
     def test_createArea(self):
-        instance = Light("name","description")
+        instance = Light("name", "description")
 
         value = instance.createArea("energyLevel")
 
-        
         assert value.isExists(), "Create method failed."
-        
+
     @unittest.skip
     def test_translateXYZ(self):
-        instance = Light("name","description")
+        instance = Light("name", "description")
 
-        value = instance.translateXYZ("x","y","z")
+        value = instance.translateXYZ("x", "y", "z")
 
-        
         assert value, "Modify method failed."
-        
+
     @unittest.skip
     def test_rotateXYZ(self):
-        instance = Light("name","description")
+        instance = Light("name", "description")
 
-        value = instance.rotateXYZ("x","y","z")
+        value = instance.rotateXYZ("x", "y", "z")
 
-        
         assert value, "Modify method failed."
-        
+
     @unittest.skip
     def test_isExists(self):
-        instance = Light("name","description")
+        instance = Light("name", "description")
 
         value = instance.isExists("")
 
-        
         assert value, "Get method failed."
-        
+
     @unittest.skip
     def test_rename(self):
-        instance = Light("name","description")
+        instance = Light("name", "description")
 
         value = instance.rename("newName")
 
-        
         assert value, "Modify method failed."
-        
+
     @unittest.skip
     def test_delete(self):
-        instance = Light("name","description")
+        instance = Light("name", "description")
 
         value = instance.delete("")
 
-        
     @unittest.skip
     def test_getNativeInstance(self):
-        instance = Light("name","description")
+        instance = Light("name", "description")
 
         value = instance.getNativeInstance("")
 
-        
         assert value, "Get method failed."
-        
+
     @unittest.skip
     def test_getLocationWorld(self):
-        instance = Light("name","description")
+        instance = Light("name", "description")
 
         value = instance.getLocationWorld("")
 
-        
         assert value, "Get method failed."
-        
+
     @unittest.skip
     def test_getLocationLocal(self):
-        instance = Light("name","description")
+        instance = Light("name", "description")
 
         value = instance.getLocationLocal("")
 
-        
         assert value, "Get method failed."
-        
+
     @unittest.skip
     def test_select(self):
-        instance = Light("name","description")
+        instance = Light("name", "description")
 
         value = instance.select("")
 
-        
+
 class TestCamera(TestProviderCase):
-    
-    
+
     @unittest.skip
     def test_createPerspective(self):
-        instance = Camera("name","description")
+        instance = Camera("name", "description")
 
         value = instance.createPerspective("")
 
-        
         assert value.isExists(), "Create method failed."
-        
+
     @unittest.skip
     def test_createOrthogonal(self):
-        instance = Camera("name","description")
+        instance = Camera("name", "description")
 
         value = instance.createOrthogonal("")
 
-        
         assert value.isExists(), "Create method failed."
-        
+
     @unittest.skip
     def test_setFocalLength(self):
-        instance = Camera("name","description")
+        instance = Camera("name", "description")
 
         value = instance.setFocalLength("length")
 
-        
         assert value, "Modify method failed."
-        
+
     @unittest.skip
     def test_translateXYZ(self):
-        instance = Camera("name","description")
+        instance = Camera("name", "description")
 
-        value = instance.translateXYZ("x","y","z")
+        value = instance.translateXYZ("x", "y", "z")
 
-        
         assert value, "Modify method failed."
-        
+
     @unittest.skip
     def test_rotateXYZ(self):
-        instance = Camera("name","description")
+        instance = Camera("name", "description")
 
-        value = instance.rotateXYZ("x","y","z")
+        value = instance.rotateXYZ("x", "y", "z")
 
-        
         assert value, "Modify method failed."
-        
+
     @unittest.skip
     def test_isExists(self):
-        instance = Camera("name","description")
+        instance = Camera("name", "description")
 
         value = instance.isExists("")
 
-        
         assert value, "Get method failed."
-        
+
     @unittest.skip
     def test_rename(self):
-        instance = Camera("name","description")
+        instance = Camera("name", "description")
 
         value = instance.rename("newName")
 
-        
         assert value, "Modify method failed."
-        
+
     @unittest.skip
     def test_delete(self):
-        instance = Camera("name","description")
+        instance = Camera("name", "description")
 
         value = instance.delete("")
 
-        
     @unittest.skip
     def test_getNativeInstance(self):
-        instance = Camera("name","description")
+        instance = Camera("name", "description")
 
         value = instance.getNativeInstance("")
 
-        
         assert value, "Get method failed."
-        
+
     @unittest.skip
     def test_getLocationWorld(self):
-        instance = Camera("name","description")
+        instance = Camera("name", "description")
 
         value = instance.getLocationWorld("")
 
-        
         assert value, "Get method failed."
-        
+
     @unittest.skip
     def test_getLocationLocal(self):
-        instance = Camera("name","description")
+        instance = Camera("name", "description")
 
         value = instance.getLocationLocal("")
 
-        
         assert value, "Get method failed."
-        
+
     @unittest.skip
     def test_select(self):
-        instance = Camera("name","description")
+        instance = Camera("name", "description")
 
         value = instance.select("")
 
-        
+
 class TestRender(TestProviderCase):
-    
+
     @unittest.skip
     def test_renderImage(self):
         instance = Render("")
 
-        value = instance.renderImage("outputFilePath","overwrite","fileType")
+        value = instance.renderImage("outputFilePath", "overwrite", "fileType")
 
-        
     @unittest.skip
     def test_renderVideoMp4(self):
         instance = Render("")
 
-        value = instance.renderVideoMp4("outputFilePath","startFrameNumber","endFrameNumber","stepFrames","overwrite")
+        value = instance.renderVideoMp4(
+            "outputFilePath", "startFrameNumber", "endFrameNumber", "stepFrames", "overwrite")
 
-        
     @unittest.skip
     def test_renderVideoFrames(self):
         instance = Render("")
 
-        value = instance.renderVideoFrames("outputFolderPath","fileNamePrefix","startFrameNumber","endFrameNumber","stepFrames","overwrite","fileType")
+        value = instance.renderVideoFrames("outputFolderPath", "fileNamePrefix",
+                                           "startFrameNumber", "endFrameNumber", "stepFrames", "overwrite", "fileType")
 
-        
     @unittest.skip
     def test_setFrameRate(self):
         instance = Render("")
 
         value = instance.setFrameRate("frameRate")
 
-        
         assert value, "Modify method failed."
-        
+
     @unittest.skip
     def test_setResolution(self):
         instance = Render("")
 
-        value = instance.setResolution("x","y")
+        value = instance.setResolution("x", "y")
 
-        
         assert value, "Modify method failed."
-        
+
     @unittest.skip
     def test_setRenderQuality(self):
         instance = Render("")
 
         value = instance.setRenderQuality("quality")
 
-        
         assert value, "Modify method failed."
-        
+
     @unittest.skip
     def test_setRenderEngine(self):
         instance = Render("")
 
         value = instance.setRenderEngine("name")
 
-        
         assert value, "Modify method failed."
-        
+
     @unittest.skip
     def test_setCamera(self):
         instance = Render("")
 
         value = instance.setCamera("cameraNameOrInstance")
 
-        
         assert value, "Modify method failed."
-        
+
+
 class TestScene(TestProviderCase):
-    
-    
-    
+
     @unittest.skip
     def test_create(self):
-        instance = Scene("name","description")
+        instance = Scene("name", "description")
 
         value = instance.create("")
 
-        
         assert value.isExists(), "Create method failed."
-        
+
     @unittest.skip
     def test_delete(self):
-        instance = Scene("name","description")
+        instance = Scene("name", "description")
 
         value = instance.delete("")
 
-        
     @unittest.skip
     def test_getSelectedEntity(self):
-        instance = Scene("name","description")
+        instance = Scene("name", "description")
 
         value = instance.getSelectedEntity("")
 
-        
         assert value, "Get method failed."
-        
+
     @unittest.skip
     def test_export(self):
-        instance = Scene("name","description")
+        instance = Scene("name", "description")
 
-        value = instance.export("filePath","entities","overwrite","scale")
+        value = instance.export("filePath", "entities", "overwrite", "scale")
 
-        
     @unittest.skip
     def test_setDefaultUnit(self):
-        instance = Scene("name","description")
+        instance = Scene("name", "description")
 
         value = instance.setDefaultUnit("unit")
 
-        
         assert value, "Modify method failed."
-        
+
     @unittest.skip
     def test_createGroup(self):
-        instance = Scene("name","description")
+        instance = Scene("name", "description")
 
         value = instance.createGroup("name")
 
-        
         assert value.isExists(), "Create method failed."
-        
+
     @unittest.skip
     def test_deleteGroup(self):
-        instance = Scene("name","description")
+        instance = Scene("name", "description")
 
-        value = instance.deleteGroup("name","removeChildren")
+        value = instance.deleteGroup("name", "removeChildren")
 
-        
     @unittest.skip
     def test_removeFromGroup(self):
-        instance = Scene("name","description")
+        instance = Scene("name", "description")
 
-        value = instance.removeFromGroup("entityName","groupName")
+        value = instance.removeFromGroup("entityName", "groupName")
 
-        
     @unittest.skip
     def test_assignToGroup(self):
-        instance = Scene("name","description")
+        instance = Scene("name", "description")
 
-        value = instance.assignToGroup("entities","groupName","removeFromOtherGroups")
+        value = instance.assignToGroup(
+            "entities", "groupName", "removeFromOtherGroups")
 
-        
         assert value, "Modify method failed."
-        
+
     @unittest.skip
     def test_setVisible(self):
-        instance = Scene("name","description")
+        instance = Scene("name", "description")
 
-        value = instance.setVisible("entities","isVisible")
+        value = instance.setVisible("entities", "isVisible")
 
-        
         assert value, "Modify method failed."
-        
+
     @unittest.skip
     def test_setBackgroundImage(self):
-        instance = Scene("name","description")
+        instance = Scene("name", "description")
 
-        value = instance.setBackgroundImage("filePath","locationX","locationY")
+        value = instance.setBackgroundImage(
+            "filePath", "locationX", "locationY")
 
-        
         assert value, "Modify method failed."
-        
+
+
 class TestAnalytics(TestProviderCase):
-    
-    
+
     @unittest.skip
     def test_measureDistance(self):
         instance = Analytics("")
 
-        value = instance.measureDistance("entity1","entity2")
+        value = instance.measureDistance("entity1", "entity2")
 
-        
         assert value, "Get method failed."
-        
+
     @unittest.skip
     def test_measureAngle(self):
         instance = Analytics("")
 
-        value = instance.measureAngle("entity1","entity2","pivot")
+        value = instance.measureAngle("entity1", "entity2", "pivot")
 
-        
         assert value, "Get method failed."
-        
+
     @unittest.skip
     def test_getWorldPose(self):
         instance = Analytics("")
 
         value = instance.getWorldPose("entity")
 
-        
         assert value, "Get method failed."
-        
+
     @unittest.skip
     def test_getBoundingBox(self):
         instance = Analytics("")
 
         value = instance.getBoundingBox("entityName")
 
-        
         assert value, "Get method failed."
-        
+
     @unittest.skip
     def test_getDimensions(self):
         instance = Analytics("")
 
         value = instance.getDimensions("entityName")
 
-        
         assert value, "Get method failed."
-        
+
     @unittest.skip
     def test_log(self):
         instance = Analytics("")
 
         value = instance.log("message")
 
-        
         assert value, "Modify method failed."
-        

--- a/CodeToCAD/capabilities.json
+++ b/CodeToCAD/capabilities.json
@@ -662,6 +662,15 @@
                     }
                 }
             },
+            "thicken": {
+                "action": "modify",
+                "information": "Uniformly add a wall around a Part.",
+                "parameters": {
+                    "radius": {
+                        "type": "string,float,Dimension"
+                    }
+                }
+            },
             "hole": {
                 "action": "modify",
                 "information": "Create a hole.",
@@ -929,16 +938,6 @@
                     }
                 }
             },
-            "thicken": {
-                "action": "get",
-                "returnType": "Part",
-                "information": "Uniformly add a wall around a sketch.",
-                "parameters": {
-                    "radius": {
-                        "type": "string,float,Dimension"
-                    }
-                }
-            },
             "extrude": {
                 "action": "get",
                 "returnType": "Part",
@@ -960,6 +959,15 @@
                     "fillCap": {
                         "type": "boolean",
                         "defaultValue": true
+                    }
+                }
+            },
+            "offset": {
+                "action": "modify",
+                "information": "Uniformly add a wall around a Sketch.",
+                "parameters": {
+                    "radius": {
+                        "type": "string,float,Dimension"
                     }
                 }
             },

--- a/docs/docs.html
+++ b/docs/docs.html
@@ -184,6 +184,8 @@
 
     <a href=#Part_hollow class="chip">hollow()</a>
 
+    <a href=#Part_thicken class="chip">thicken()</a>
+
     <a href=#Part_hole class="chip">hole()</a>
 
     <a href=#Part_setMaterial class="chip">setMaterial()</a>
@@ -300,11 +302,11 @@
 
     <a href=#Sketch_revolve class="chip">revolve()</a>
 
-    <a href=#Sketch_thicken class="chip">thicken()</a>
-
     <a href=#Sketch_extrude class="chip">extrude()</a>
 
     <a href=#Sketch_sweep class="chip">sweep()</a>
+
+    <a href=#Sketch_offset class="chip">offset()</a>
 
     <a href=#Sketch_profile class="chip">profile()</a>
 
@@ -1390,6 +1392,25 @@
             
             <div><span class="subSubHeading">Type:</span> boolean</div>
             <div><span class="subSubHeading">Default Value:</span> False</div>
+            
+        </div>
+    </div>
+
+
+    
+
+    Part::<span class="subHeading" id=Part_thicken>thicken(radius)</span>
+
+    <div class="methods">Uniformly add a wall around a Part.</div>
+    
+    
+
+    <div class="methods grid-container-parameters">
+        <div class="methodName grid-item">radius</div>
+        <div class="grid-item">
+            
+            <div><span class="subSubHeading">Type:</span> string,float,Dimension</div>
+            
             
         </div>
     </div>
@@ -3090,25 +3111,6 @@
 
     
 
-    Sketch::<span class="subHeading" id=Sketch_thicken>thicken(radius)</span>
-
-    <div class="methods">Uniformly add a wall around a sketch.</div>
-    <div><span class="subSubHeading">returnType:</span> Part</div>
-    
-
-    <div class="methods grid-container-parameters">
-        <div class="methodName grid-item">radius</div>
-        <div class="grid-item">
-            
-            <div><span class="subSubHeading">Type:</span> string,float,Dimension</div>
-            
-            
-        </div>
-    </div>
-
-
-    
-
     Sketch::<span class="subHeading" id=Sketch_extrude>extrude(length)</span>
 
     <div class="methods">Extrude a curve by a specified length. Returns a Part type.</div>
@@ -3154,6 +3156,25 @@
             
             <div><span class="subSubHeading">Type:</span> boolean</div>
             <div><span class="subSubHeading">Default Value:</span> True</div>
+            
+        </div>
+    </div>
+
+
+    
+
+    Sketch::<span class="subHeading" id=Sketch_offset>offset(radius)</span>
+
+    <div class="methods">Uniformly add a wall around a Sketch.</div>
+    
+    
+
+    <div class="methods grid-container-parameters">
+        <div class="methodName grid-item">radius</div>
+        <div class="grid-item">
+            
+            <div><span class="subSubHeading">Type:</span> string,float,Dimension</div>
+            
             
         </div>
     </div>

--- a/providers/blender/BlenderActions.py
+++ b/providers/blender/BlenderActions.py
@@ -1634,36 +1634,41 @@ def addonSetEnabled(addonName: str, isEnabled: bool):
 
 # MARK: Curves and Sketches
 
-def extrude(
-    curveObjectName: str,
+def getCurve(curveName: str) -> bpy.types.Curve:
+
+    curve = bpy.data.curves.get(curveName)
+
+    assert \
+        curve is not None, \
+        f"Curve {curveName} does not exists"
+
+    return curve
+
+
+def extrudeCurve(
+    curveName: str,
     length: Utilities.Dimension
 ):
 
-    blenderObject = getObject(curveObjectName)
+    curve = getCurve(curveName)
 
     length = BlenderDefinitions.BlenderLength.convertDimensionToBlenderUnit(
         length)
 
-    assert type(blenderObject.data) == BlenderDefinitions.BlenderTypes.CURVE.value or type(blenderObject.data) == BlenderDefinitions.BlenderTypes.TEXT.value,\
-        f"Object {curveObjectName} is not a curve or text object type."
-
-    blenderObject.data.extrude = length.value
+    curve.extrude = length.value
 
 
 def offsetCurveGeometry(
-    curveObjectName: str,
+    curveName: str,
     offset: Utilities.Dimension
 ):
 
-    blenderObject = getObject(curveObjectName)
+    curve = getCurve(curveName)
 
     length = BlenderDefinitions.BlenderLength.convertDimensionToBlenderUnit(
         offset)
 
-    assert type(blenderObject.data) == BlenderDefinitions.BlenderTypes.CURVE.value or type(blenderObject.data) == BlenderDefinitions.BlenderTypes.TEXT.value,\
-        f"Object {curveObjectName} is not a curve or text object type."
-
-    blenderObject.data.offset = length.value
+    curve.offset = length.value
 
 
 def createText(curveName: str, text: str,

--- a/providers/blender/BlenderActions.py
+++ b/providers/blender/BlenderActions.py
@@ -1241,7 +1241,6 @@ def addVerticiesToVertexGroup(
 
 def createMeshFromCurve(
     existingCurveObjectName: str,
-    isRecalculateNormals: bool,
     newObjectName: Optional[str] = None,
 ):
 
@@ -1272,9 +1271,6 @@ def createMeshFromCurve(
     # twisted logic here, but if we renamed this above, we want to nuke it because we're done with it.
     if existingCurveObject.name != existingCurveObjectName:
         removeObject(existingCurveObject.name, removeChildren=True)
-
-    if isRecalculateNormals:
-        recalculateNormals(newObjectName)
 
 
 def getObjectVisibility(

--- a/providers/blender/BlenderActions.py
+++ b/providers/blender/BlenderActions.py
@@ -1671,6 +1671,26 @@ def offsetCurveGeometry(
     curve.offset = length.value
 
 
+def setCurveResolutionU(
+        curveName: str,
+        resolution: int
+):
+
+    curve = getCurve(curveName)
+
+    curve.resolution_u = resolution
+
+
+def setCurveResolutionV(
+        curveName: str,
+        resolution: int
+):
+
+    curve = getCurve(curveName)
+
+    curve.resolution_v = resolution
+
+
 def createText(curveName: str, text: str,
                size=Utilities.Dimension(1),
                bold=False,

--- a/providers/blender/BlenderActions.py
+++ b/providers/blender/BlenderActions.py
@@ -1241,7 +1241,8 @@ def addVerticiesToVertexGroup(
 
 def createMeshFromCurve(
     existingCurveObjectName: str,
-    newObjectName: Optional[str] = None
+    isRecalculateNormals: bool,
+    newObjectName: Optional[str] = None,
 ):
 
     existingCurveObject = getObject(existingCurveObjectName)
@@ -1272,8 +1273,8 @@ def createMeshFromCurve(
     if existingCurveObject.name != existingCurveObjectName:
         removeObject(existingCurveObject.name, removeChildren=True)
 
-    # Recalcuate face normals because they're usually really wrong:
-    recalculateNormals(newObjectName)
+    if isRecalculateNormals:
+        recalculateNormals(newObjectName)
 
 
 def getObjectVisibility(
@@ -1487,24 +1488,19 @@ def isCollisionBetweenTwoObjects(
     blenderObject2 = getObject(object2Name)
 
     # References https://blender.stackexchange.com/a/144609
-    # create bmesh objects
     bm1 = bmesh.new()
     bm2 = bmesh.new()
 
-    # fill bmesh data from objects
     bm1.from_mesh(getMesh(blenderObject1.name))
     bm2.from_mesh(getMesh(blenderObject2.name))
 
-    # fixed it here:
-    bm1.transform(blenderObject1.matrix_world)
-    bm2.transform(blenderObject2.matrix_world)
+    bm1.transform(blenderObject1.matrix_world)  # type: ignore
+    bm2.transform(blenderObject2.matrix_world)  # type: ignore
 
-    # make BVH tree from BMesh of objects
     obj_now_BVHtree = BVHTree.FromBMesh(bm1)
     obj_next_BVHtree = BVHTree.FromBMesh(bm2)
 
-    # get intersecting pairs
-    uniqueIndecies = obj_now_BVHtree.overlap(obj_next_BVHtree)
+    uniqueIndecies = obj_now_BVHtree.overlap(obj_next_BVHtree)  # type: ignore
 
     return len(uniqueIndecies) > 0
 

--- a/providers/blender/BlenderActions.py
+++ b/providers/blender/BlenderActions.py
@@ -1650,6 +1650,22 @@ def extrude(
     blenderObject.data.extrude = length.value
 
 
+def offsetCurveGeometry(
+    curveObjectName: str,
+    offset: Utilities.Dimension
+):
+
+    blenderObject = getObject(curveObjectName)
+
+    length = BlenderDefinitions.BlenderLength.convertDimensionToBlenderUnit(
+        offset)
+
+    assert type(blenderObject.data) == BlenderDefinitions.BlenderTypes.CURVE.value or type(blenderObject.data) == BlenderDefinitions.BlenderTypes.TEXT.value,\
+        f"Object {curveObjectName} is not a curve or text object type."
+
+    blenderObject.data.offset = length.value
+
+
 def createText(curveName: str, text: str,
                size=Utilities.Dimension(1),
                bold=False,

--- a/providers/blender/BlenderProvider.py
+++ b/providers/blender/BlenderProvider.py
@@ -745,6 +745,15 @@ class Part(Entity, CodeToCADInterface.Part):
 
         return self.applyModifiersOnly()
 
+    def thicken(self, radius: DimensionOrItsFloatOrStringValue) -> 'Part':
+
+        radius = Utilities.Dimension.fromString(radius)
+
+        BlenderActions.applySolidifyModifier(
+            self.name, radius)
+
+        return self.applyModifiersOnly()
+
     def hole(self, holeLandmark: LandmarkOrItsName, radius: DimensionOrItsFloatOrStringValue, depth: DimensionOrItsFloatOrStringValue, normalAxis: AxisOrItsIndexOrItsName = "z", flipAxis: bool = False, initialRotationX: AngleOrItsFloatOrStringValue = 0.0, initialRotationY: AngleOrItsFloatOrStringValue = 0.0, initialRotationZ: AngleOrItsFloatOrStringValue = 0.0, mirrorAboutEntityOrLandmark: Optional[EntityOrItsNameOrLandmark] = None, mirrorAxis: AxisOrItsIndexOrItsName = "x", mirror: bool = False, circularPatternInstanceCount: 'int' = 1, circularPatternInstanceSeparation: AngleOrItsFloatOrStringValue = 0.0, circularPatternInstanceAxis: AxisOrItsIndexOrItsName = "z", circularPatternAboutEntityOrLandmark: Optional[EntityOrItsNameOrLandmark] = None, linearPatternInstanceCount: 'int' = 1, linearPatternInstanceSeparation: DimensionOrItsFloatOrStringValue = 0.0, linearPatternInstanceAxis: AxisOrItsIndexOrItsName = "x", linearPattern2ndInstanceCount: 'int' = 1, linearPattern2ndInstanceSeparation: DimensionOrItsFloatOrStringValue = 0.0, linearPattern2ndInstanceAxis: AxisOrItsIndexOrItsName = "y"):
 
         axis = Utilities.Axis.fromString(normalAxis)
@@ -993,19 +1002,14 @@ class Sketch(Entity, CodeToCADInterface.Sketch):
 
         return Part(self.name, self.description).apply()
 
-    def thicken(self, radius: DimensionOrItsFloatOrStringValue) -> 'Part':
+    def offset(self, radius: DimensionOrItsFloatOrStringValue):
 
         radius = Utilities.Dimension.fromString(radius)
 
-        BlenderActions.applySolidifyModifier(
+        BlenderActions.offsetCurveGeometry(
             self.name, radius)
 
-        BlenderActions.createMeshFromCurve(
-            self.name, isRecalculateNormals=False)
-
-        part = Part(self.name, self.description).apply()
-
-        return part
+        return self
 
     def extrude(self, length: DimensionOrItsFloatOrStringValue) -> 'Part':
 

--- a/providers/blender/BlenderProvider.py
+++ b/providers/blender/BlenderProvider.py
@@ -988,25 +988,32 @@ class Sketch(Entity, CodeToCADInterface.Sketch):
         BlenderActions.applyScrewModifier(self.name, Utilities.Angle.fromString(
             angle).toRadians(), axis, entityNameToDetermineAxis=aboutEntityOrLandmark)
 
-        BlenderActions.createMeshFromCurve(self.name)
+        BlenderActions.createMeshFromCurve(
+            self.name, isRecalculateNormals=False)
 
         return Part(self.name, self.description).apply()
 
     def thicken(self, radius: DimensionOrItsFloatOrStringValue) -> 'Part':
 
+        radius = Utilities.Dimension.fromString(radius)
+
         BlenderActions.applySolidifyModifier(
-            self.name, Utilities.Dimension.fromString(radius))
+            self.name, radius)
 
-        BlenderActions.createMeshFromCurve(self.name)
+        BlenderActions.createMeshFromCurve(
+            self.name, isRecalculateNormals=False)
 
-        return Part(self.name, self.description).apply()
+        part = Part(self.name, self.description).apply()
+
+        return part
 
     def extrude(self, length: DimensionOrItsFloatOrStringValue) -> 'Part':
 
         BlenderActions.extrude(
             self.name, Utilities.Dimension.fromString(length))
 
-        BlenderActions.createMeshFromCurve(self.name)
+        BlenderActions.createMeshFromCurve(
+            self.name, isRecalculateNormals=False)
 
         return Part(self.name, self.description).apply()
 
@@ -1018,7 +1025,8 @@ class Sketch(Entity, CodeToCADInterface.Sketch):
         BlenderActions.addBevelObjectToCurve(
             self.name, profileCurveName, fillCap)
 
-        BlenderActions.createMeshFromCurve(self.name)
+        BlenderActions.createMeshFromCurve(
+            self.name, isRecalculateNormals=False)
 
         return Part(self.name, self.description).apply()
 

--- a/providers/blender/BlenderProvider.py
+++ b/providers/blender/BlenderProvider.py
@@ -998,7 +998,7 @@ class Sketch(Entity, CodeToCADInterface.Sketch):
             angle).toRadians(), axis, entityNameToDetermineAxis=aboutEntityOrLandmark)
 
         BlenderActions.createMeshFromCurve(
-            self.name, isRecalculateNormals=False)
+            self.name)
 
         return Part(self.name, self.description).apply()
 
@@ -1017,7 +1017,7 @@ class Sketch(Entity, CodeToCADInterface.Sketch):
             self.name, Utilities.Dimension.fromString(length))
 
         BlenderActions.createMeshFromCurve(
-            self.name, isRecalculateNormals=False)
+            self.name)
 
         return Part(self.name, self.description).apply()
 
@@ -1030,7 +1030,10 @@ class Sketch(Entity, CodeToCADInterface.Sketch):
             self.name, profileCurveName, fillCap)
 
         BlenderActions.createMeshFromCurve(
-            self.name, isRecalculateNormals=False)
+            self.name)
+
+        # Recalculate normals because they're usually wrong after sweeping.
+        BlenderActions.recalculateNormals(self.name)
 
         return Part(self.name, self.description).apply()
 

--- a/providers/blender/BlenderProvider.py
+++ b/providers/blender/BlenderProvider.py
@@ -1013,7 +1013,7 @@ class Sketch(Entity, CodeToCADInterface.Sketch):
 
     def extrude(self, length: DimensionOrItsFloatOrStringValue) -> 'Part':
 
-        BlenderActions.extrude(
+        BlenderActions.extrudeCurve(
             self.name, Utilities.Dimension.fromString(length))
 
         BlenderActions.createMeshFromCurve(

--- a/providers/onshape/OnshapeProvider.py
+++ b/providers/onshape/OnshapeProvider.py
@@ -244,6 +244,10 @@ class Part(Entity, CodeToCADInterface.Part):
 
         return self
 
+    def thicken(self, radius: DimensionOrItsFloatOrStringValue):
+
+        return self
+
     def hole(self, holeLandmark: LandmarkOrItsName, radius: DimensionOrItsFloatOrStringValue, depth: DimensionOrItsFloatOrStringValue, normalAxis: AxisOrItsIndexOrItsName = "z", flipAxis: bool = False, initialRotationX: AngleOrItsFloatOrStringValue = 0.0, initialRotationY: AngleOrItsFloatOrStringValue = 0.0, initialRotationZ: AngleOrItsFloatOrStringValue = 0.0, mirrorAboutEntityOrLandmark: Optional[EntityOrItsNameOrLandmark] = None, mirrorAxis: AxisOrItsIndexOrItsName = "x", mirror: bool = False, circularPatternInstanceCount: 'int' = 1, circularPatternInstanceSeparation: AngleOrItsFloatOrStringValue = 0.0, circularPatternInstanceAxis: AxisOrItsIndexOrItsName = "z", circularPatternAboutEntityOrLandmark: Optional[EntityOrItsNameOrLandmark] = None, linearPatternInstanceCount: 'int' = 1, linearPatternInstanceSeparation: DimensionOrItsFloatOrStringValue = 0.0, linearPatternInstanceAxis: AxisOrItsIndexOrItsName = "x", linearPattern2ndInstanceCount: 'int' = 1, linearPattern2ndInstanceSeparation: DimensionOrItsFloatOrStringValue = 0.0, linearPattern2ndInstanceAxis: AxisOrItsIndexOrItsName = "y"):
 
         return self
@@ -312,7 +316,7 @@ class Sketch(Entity, CodeToCADInterface.Sketch):
 
         raise NotImplementedError()
 
-    def thicken(self, radius: DimensionOrItsFloatOrStringValue) -> 'Part':
+    def offset(self, radius: DimensionOrItsFloatOrStringValue):
 
         raise NotImplementedError()
 

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -530,6 +530,14 @@ class TestPart(TestProviderCase):
         assert value, "Modify method failed."
 
     @unittest.skip
+    def test_thicken(self):
+        instance = Part("")
+
+        value = instance.thicken("radius")
+
+        assert value, "Modify method failed."
+
+    @unittest.skip
     def test_hole(self):
         instance = Part("TestPart")
 
@@ -633,10 +641,10 @@ class TestSketch(TestProviderCase):
         assert value, "Modify method failed."
 
     @unittest.skip
-    def test_thicken(self):
+    def test_offset(self):
         instance = Sketch("name", "curveType", "description")
 
-        value = instance.thicken("radius")
+        value = instance.offset("radius")
 
         assert value, "Modify method failed."
 


### PR DESCRIPTION
This introduces a breaking change to `Sketch.thicken`:
- Renamed `Sketch.thicken` to `Sketch.offset`
- Created a new `Part.thicken` method.
- We were using the wrong modifier for thickening/offseting a sketch/curve wall.
  - We now use Offset geometry for Sketches/Curves, and use the solidify modifier for Parts in BlenderProvider.


Out of bound changes:
- Recalculating normals does not happen automatically when converting a Curve to a Mesh in BlenderActions, instead it only happens after sweeping in BlenderProvider now.
- Added a `getCurve` functions in BlenderActions
- Add `setCurveResolutionU` and `setCurveResolutionV` functions in BlenderActions