### PR TITLE
Fixed improper wrapping of BlenderProvider's Sketch methods causing them to not expose correct method parameters

### DIFF
--- a/providers/blender/blenderProvider/Analytics.py
+++ b/providers/blender/blenderProvider/Analytics.py
@@ -1,7 +1,4 @@
-# THIS IS AN AUTO-GENERATE FILE.
-# DO NOT EDIT MANUALLY.
-# Please run development/capabilitiesJsonToPython/capabilitiesToPy.sh to generate this file.
-# Copy this file and remove this header to create a new CodeToCAD Provider.
+
 
 from typing import Optional
 

--- a/providers/blender/blenderProvider/Animation.py
+++ b/providers/blender/blenderProvider/Animation.py
@@ -1,7 +1,4 @@
-# THIS IS AN AUTO-GENERATE FILE.
-# DO NOT EDIT MANUALLY.
-# Please run development/capabilitiesJsonToPython/capabilitiesToPy.sh to generate this file.
-# Copy this file and remove this header to create a new CodeToCAD Provider.
+
 
 from typing import Optional
 

--- a/providers/blender/blenderProvider/Camera.py
+++ b/providers/blender/blenderProvider/Camera.py
@@ -1,7 +1,4 @@
-# THIS IS AN AUTO-GENERATE FILE.
-# DO NOT EDIT MANUALLY.
-# Please run development/capabilitiesJsonToPython/capabilitiesToPy.sh to generate this file.
-# Copy this file and remove this header to create a new CodeToCAD Provider.
+
 
 from typing import Optional
 

--- a/providers/blender/blenderProvider/Entity.py
+++ b/providers/blender/blenderProvider/Entity.py
@@ -1,7 +1,4 @@
-# THIS IS AN AUTO-GENERATE FILE.
-# DO NOT EDIT MANUALLY.
-# Please run development/capabilitiesJsonToPython/capabilitiesToPy.sh to generate this file.
-# Copy this file and remove this header to create a new CodeToCAD Provider.
+
 
 from typing import Optional
 from . import BlenderActions

--- a/providers/blender/blenderProvider/Joint.py
+++ b/providers/blender/blenderProvider/Joint.py
@@ -1,7 +1,4 @@
-# THIS IS AN AUTO-GENERATE FILE.
-# DO NOT EDIT MANUALLY.
-# Please run development/capabilitiesJsonToPython/capabilitiesToPy.sh to generate this file.
-# Copy this file and remove this header to create a new CodeToCAD Provider.
+
 
 from typing import Optional
 

--- a/providers/blender/blenderProvider/Landmark.py
+++ b/providers/blender/blenderProvider/Landmark.py
@@ -1,8 +1,3 @@
-# THIS IS AN AUTO-GENERATE FILE.
-# DO NOT EDIT MANUALLY.
-# Please run development/capabilitiesJsonToPython/capabilitiesToPy.sh to generate this file.
-# Copy this file and remove this header to create a new CodeToCAD Provider.
-
 from typing import Optional
 
 from . import BlenderActions

--- a/providers/blender/blenderProvider/Light.py
+++ b/providers/blender/blenderProvider/Light.py
@@ -1,8 +1,3 @@
-# THIS IS AN AUTO-GENERATE FILE.
-# DO NOT EDIT MANUALLY.
-# Please run development/capabilitiesJsonToPython/capabilitiesToPy.sh to generate this file.
-# Copy this file and remove this header to create a new CodeToCAD Provider.
-
 from typing import Optional
 
 from . import BlenderActions

--- a/providers/blender/blenderProvider/Material.py
+++ b/providers/blender/blenderProvider/Material.py
@@ -1,8 +1,3 @@
-# THIS IS AN AUTO-GENERATE FILE.
-# DO NOT EDIT MANUALLY.
-# Please run development/capabilitiesJsonToPython/capabilitiesToPy.sh to generate this file.
-# Copy this file and remove this header to create a new CodeToCAD Provider.
-
 from typing import Optional
 
 from . import BlenderActions

--- a/providers/blender/blenderProvider/Part.py
+++ b/providers/blender/blenderProvider/Part.py
@@ -1,8 +1,3 @@
-# THIS IS AN AUTO-GENERATE FILE.
-# DO NOT EDIT MANUALLY.
-# Please run development/capabilitiesJsonToPython/capabilitiesToPy.sh to generate this file.
-# Copy this file and remove this header to create a new CodeToCAD Provider.
-
 from typing import Optional
 from . import BlenderActions
 from . import BlenderDefinitions

--- a/providers/blender/blenderProvider/Render.py
+++ b/providers/blender/blenderProvider/Render.py
@@ -1,8 +1,3 @@
-# THIS IS AN AUTO-GENERATE FILE.
-# DO NOT EDIT MANUALLY.
-# Please run development/capabilitiesJsonToPython/capabilitiesToPy.sh to generate this file.
-# Copy this file and remove this header to create a new CodeToCAD Provider.
-
 from typing import Optional
 
 from . import BlenderActions

--- a/providers/blender/blenderProvider/Scene.py
+++ b/providers/blender/blenderProvider/Scene.py
@@ -1,8 +1,3 @@
-# THIS IS AN AUTO-GENERATE FILE.
-# DO NOT EDIT MANUALLY.
-# Please run development/capabilitiesJsonToPython/capabilitiesToPy.sh to generate this file.
-# Copy this file and remove this header to create a new CodeToCAD Provider.
-
 from typing import Optional
 
 from . import BlenderActions

--- a/providers/blender/blenderProvider/Sketch.py
+++ b/providers/blender/blenderProvider/Sketch.py
@@ -1,13 +1,13 @@
+from functools import wraps
 from typing import Optional
-from . import BlenderActions
-from . import BlenderDefinitions
 
-from CodeToCAD.interfaces import SketchInterface
 from CodeToCAD.CodeToCADTypes import *
+from CodeToCAD.interfaces import SketchInterface
 from CodeToCAD.utilities import *
 
-from .Part import Part
+from . import BlenderActions, BlenderDefinitions
 from .Entity import Entity
+from .Part import Part
 
 
 class Sketch(Entity, SketchInterface):
@@ -112,6 +112,8 @@ class Sketch(Entity, SketchInterface):
     @staticmethod
     def _createPrimitiveDecorator(curvePrimitiveType: CurvePrimitiveTypes):
         def decorator(primitiveFunction):
+
+            @wraps(primitiveFunction)
             def wrapper(*args, **kwargs):
 
                 self = args[0]

--- a/providers/blender/blenderProvider/Sketch.py
+++ b/providers/blender/blenderProvider/Sketch.py
@@ -1,8 +1,3 @@
-# THIS IS AN AUTO-GENERATE FILE.
-# DO NOT EDIT MANUALLY.
-# Please run development/capabilitiesJsonToPython/capabilitiesToPy.sh to generate this file.
-# Copy this file and remove this header to create a new CodeToCAD Provider.
-
 from typing import Optional
 from . import BlenderActions
 from . import BlenderDefinitions

--- a/providers/onshape/onshapeProvider/Entity.py
+++ b/providers/onshape/onshapeProvider/Entity.py
@@ -1,7 +1,4 @@
-# THIS IS AN AUTO-GENERATE FILE.
-# DO NOT EDIT MANUALLY.
-# Please run development/capabilitiesJsonToPython/capabilitiesToPy.sh to generate this file.
-# Copy this file and remove this header to create a new CodeToCAD Provider.
+
 
 from typing import Optional
 

--- a/providers/onshape/onshapeProvider/Landmark.py
+++ b/providers/onshape/onshapeProvider/Landmark.py
@@ -1,7 +1,4 @@
-# THIS IS AN AUTO-GENERATE FILE.
-# DO NOT EDIT MANUALLY.
-# Please run development/capabilitiesJsonToPython/capabilitiesToPy.sh to generate this file.
-# Copy this file and remove this header to create a new CodeToCAD Provider.
+
 
 from typing import Optional
 

--- a/providers/onshape/onshapeProvider/Light.py
+++ b/providers/onshape/onshapeProvider/Light.py
@@ -1,7 +1,4 @@
-# THIS IS AN AUTO-GENERATE FILE.
-# DO NOT EDIT MANUALLY.
-# Please run development/capabilitiesJsonToPython/capabilitiesToPy.sh to generate this file.
-# Copy this file and remove this header to create a new CodeToCAD Provider.
+
 
 from typing import Optional
 

--- a/providers/onshape/onshapeProvider/Part.py
+++ b/providers/onshape/onshapeProvider/Part.py
@@ -1,7 +1,4 @@
-# THIS IS AN AUTO-GENERATE FILE.
-# DO NOT EDIT MANUALLY.
-# Please run development/capabilitiesJsonToPython/capabilitiesToPy.sh to generate this file.
-# Copy this file and remove this header to create a new CodeToCAD Provider.
+
 
 from typing import Optional
 

--- a/providers/onshape/onshapeProvider/Scene.py
+++ b/providers/onshape/onshapeProvider/Scene.py
@@ -1,7 +1,4 @@
-# THIS IS AN AUTO-GENERATE FILE.
-# DO NOT EDIT MANUALLY.
-# Please run development/capabilitiesJsonToPython/capabilitiesToPy.sh to generate this file.
-# Copy this file and remove this header to create a new CodeToCAD Provider.
+
 
 from typing import Optional
 

--- a/providers/onshape/onshapeProvider/Sketch.py
+++ b/providers/onshape/onshapeProvider/Sketch.py
@@ -1,7 +1,4 @@
-# THIS IS AN AUTO-GENERATE FILE.
-# DO NOT EDIT MANUALLY.
-# Please run development/capabilitiesJsonToPython/capabilitiesToPy.sh to generate this file.
-# Copy this file and remove this header to create a new CodeToCAD Provider.
+
 
 from typing import Optional
 


### PR DESCRIPTION
Out of bounds change:
- Removed misleading "This File is Auto-Generated" message from providers