### PR TITLE
Bug/255 add black to prehooks

### DIFF
--- a/development/git_hooks/pre-commit.sh
+++ b/development/git_hooks/pre-commit.sh
@@ -15,12 +15,12 @@ echo "$FILES" | xargs black
 # Add back the modified/prettified files to staging
 echo "$FILES" | xargs git add
 
-NO_EMPTY=git diff --cached --exit-code
-if [ $NO_EMPTY -eq 0 ]
-then
-    echo "Black formatting resulted in an empty commit, cancelling!"
-    exit 1
-fi
+# NO_EMPTY=git diff --cached --exit-code
+# if [ $NO_EMPTY -eq 0 ]
+# then
+#     echo "Black formatting resulted in an empty commit, cancelling!"
+#     exit 1
+# fi
 
 # Mark: run tests  and lint checks
 sh "$ROOT_DIR/development/run_tests.sh"

--- a/development/git_hooks/pre-commit.sh
+++ b/development/git_hooks/pre-commit.sh
@@ -4,8 +4,25 @@ ROOT_DIR=`git rev-parse --show-toplevel`
 
 set -e # exit if script errors.
 
-echo "Running pre-commit hooks."
+# Reference: https://prettier.io/docs/en/precommit.html
+# ACMR = Added, Copied, Modified, Renamed (no deleted)
+FILES=$(git diff --cached --name-only --diff-filter=ACMR | grep '\.\(py\)$' | sed 's| |\\ |g')
+[ -z "$FILES" ] && exit 0
 
+# Prettify all selected files
+echo "$FILES" | xargs black
+
+# Add back the modified/prettified files to staging
+echo "$FILES" | xargs git add
+
+NO_EMPTY=git diff --cached --exit-code
+if [ $NO_EMPTY -eq 0 ]
+then
+    echo "Black formatting resulted in an empty commit, cancelling!"
+    exit 1
+fi
+
+# Mark: run tests  and lint checks
 sh "$ROOT_DIR/development/run_tests.sh"
 
 sh "$ROOT_DIR/development/run_lint.sh"

--- a/development/requirements.txt
+++ b/development/requirements.txt
@@ -9,6 +9,7 @@ jinja2-cli
 # Blender Development Dependencies:
 fake-bpy-module-latest==20231025
 numpy
+black
 
 # Onshape Development Dependencies:
 onshape-client

--- a/development/utilities.py
+++ b/development/utilities.py
@@ -1,5 +1,6 @@
 import re
 
+
 pattern1 = re.compile(r"(.)([A-Z][a-z]+)")
 pattern2 = re.compile(r"__([A-Z])")
 pattern3 = re.compile(r"([a-z0-9])([A-Z])")


### PR DESCRIPTION
This branch adds black python formatting to pre-commit hooks. 

I used some code from the [prettier documentation](https://prettier.io/docs/en/precommit.html) to get the list of files and apply formatting to them before re-adding the files for staging in the commit.

There is a possible bug where black could create an empty commit, but adding the code to fix it caused an issue (`git diff unrecognized option --cached`), so I left the code in, but commented out. 

I tested it on commits both with and without python files, and python files that needed reformatting and it worked.
That's why `development/utilities.py` got an extra space.

Closes #255 