### PR TITLE
Update supported decorators to annotate support for calls in Entity.py

### DIFF
--- a/providers/blender/blender_provider/entity.py
+++ b/providers/blender/blender_provider/entity.py
@@ -85,7 +85,7 @@ class Entity(EntityInterface):
     def _apply_rotation_and_scale_only(self):
         return self.apply(rotation=True, scale=True, location=False, modifiers=False)
 
-    @supported(SupportLevel.UNSUPPORTED)
+    @supported(SupportLevel.SUPPORTED)
     def apply(
         self,
         rotation: "bool" = True,
@@ -108,17 +108,17 @@ class Entity(EntityInterface):
     def get_native_instance(self) -> object:
         return get_object(self.name)
 
-    @supported(SupportLevel.UNSUPPORTED)
+    @supported(SupportLevel.SUPPORTED, notes="Gets object's location in world coordinate")
     def get_location_world(self) -> "Point":
         update_view_layer()
         return get_object_world_location(self.name)
 
-    @supported(SupportLevel.UNSUPPORTED)
+    @supported(SupportLevel.SUPPORTED, notes="Gets object's location in local coordinate")
     def get_location_local(self) -> "Point":
         update_view_layer()
         return get_object_local_location(self.name)
 
-    @supported(SupportLevel.UNSUPPORTED)
+    @supported(SupportLevel.SUPPORTED, notes="Selects object depend on object's name")
     def select(self):
         select_object(self.name)
         return self
@@ -133,7 +133,7 @@ class Entity(EntityInterface):
         )
         return BlenderLength.convert_dimension_to_blender_unit(dimension)
 
-    @supported(SupportLevel.SUPPORTED)
+    @supported(SupportLevel.SUPPORTED, notes="Translate object for axis")
     def translate_xyz(
         self,
         x: "str|float|Dimension",
@@ -166,7 +166,7 @@ class Entity(EntityInterface):
         )
         return self
 
-    @supported(SupportLevel.UNSUPPORTED)
+    @supported(SupportLevel.SUPPORTED, notes="Translate object for axis X")
     def translate_x(self, amount: "str|float|Dimension"):
         boundingBox = get_bounding_box(self.name)
         assert boundingBox.x, "Could not get bounding box"
@@ -180,7 +180,7 @@ class Entity(EntityInterface):
         )
         return self
 
-    @supported(SupportLevel.UNSUPPORTED)
+    @supported(SupportLevel.SUPPORTED, notes="Translate object for axis X")
     def translate_y(self, amount: "str|float|Dimension"):
         boundingBox = get_bounding_box(self.name)
         assert boundingBox.y, "Could not get bounding box"
@@ -194,7 +194,7 @@ class Entity(EntityInterface):
         )
         return self
 
-    @supported(SupportLevel.UNSUPPORTED)
+    @supported(SupportLevel.SUPPORTED, notes="Translate object for axis X")
     def translate_z(self, amount: "str|float|Dimension"):
         boundingBox = get_bounding_box(self.name)
         assert boundingBox.z, "Could not get bounding box"
@@ -208,7 +208,7 @@ class Entity(EntityInterface):
         )
         return self
 
-    @supported(SupportLevel.UNSUPPORTED)
+    @supported(SupportLevel.SUPPORTED, notes="Rotate object for axis X, Y, Z")
     def rotate_xyz(
         self, x: "str|float|Angle", y: "str|float|Angle", z: "str|float|Angle"
     ):
@@ -218,29 +218,29 @@ class Entity(EntityInterface):
         rotate_object(self.name, [xAngle, yAngle, zAngle], BlenderRotationTypes.EULER)
         return self._apply_rotation_and_scale_only()
 
-    @supported(SupportLevel.UNSUPPORTED)
+    @supported(SupportLevel.SUPPORTED, notes="Rotate object for axis X")
     def rotate_x(self, rotation: "str|float|Angle"):
         angle = Angle.from_angle_or_its_float_or_string_value(rotation)
         rotate_object(self.name, [angle, None, None], BlenderRotationTypes.EULER)
         return self._apply_rotation_and_scale_only()
 
-    @supported(SupportLevel.UNSUPPORTED)
+    @supported(SupportLevel.SUPPORTED, notes="Rotate object for axis Y")
     def rotate_y(self, rotation: "str|float|Angle"):
         angle = Angle.from_angle_or_its_float_or_string_value(rotation)
         rotate_object(self.name, [None, angle, None], BlenderRotationTypes.EULER)
         return self._apply_rotation_and_scale_only()
 
-    @supported(SupportLevel.UNSUPPORTED)
+    @supported(SupportLevel.SUPPORTED, notes="Rotate object for axis Z")
     def rotate_z(self, rotation: "str|float|Angle"):
         angle = Angle.from_angle_or_its_float_or_string_value(rotation)
         rotate_object(self.name, [None, None, angle], BlenderRotationTypes.EULER)
         return self._apply_rotation_and_scale_only()
 
-    @supported(SupportLevel.UNSUPPORTED)
+    @supported(SupportLevel.SUPPORTED, notes="Gets value for object's bounding box")
     def get_bounding_box(self) -> "BoundaryBox":
         return get_bounding_box(self.name)
 
-    @supported(SupportLevel.UNSUPPORTED)
+    @supported(SupportLevel.SUPPORTED, notes="Gets value for object's dimensions")
     def get_dimensions(self) -> "Dimensions":
         dimensions = get_object(self.name).dimensions
         dimensions = [


### PR DESCRIPTION
I have update these decorators.

- is_exists()
- rename()
- delete()
- set_visible()
- apply()
- get_native_instance()
- get_location_world()
- get_location_local()
- select()
- translate_xyz()
- translate_x()
- translate_y()
- translate_z()
- rotate_xyz()
- rotate_x()
- rotate_y()
- rotate_z()
- get_bounding_box()
- get_dimensions()