### PR TITLE
Release - @supported decorators

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -12,8 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
         - name: Checkout code
-          uses: actions/checkout@v3
+          uses: actions/checkout@v4
           with:
+            fetch-depth: 0
             fetch-tags: true
         - name: Assign Git Commit Epoch to $GITHUB_OUTPUT
           id: git_commit_epoch


### PR DESCRIPTION
Creating a release after we manually updated the @supported decorators. BlenderProvider and Fusion360 provider still have bugs in SUPPORTED and PARTIAL capabilities, but those will be fixed in a later release.